### PR TITLE
Add workflow to publish packages on packages.credativ.com

### DIFF
--- a/.github/workflows/40-build-and-publish-deb-package.yml
+++ b/.github/workflows/40-build-and-publish-deb-package.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Build Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y debhelper dh-make devscripts git-buildpackage build-essential
+        sudo apt-get install -y debhelper dh-make devscripts git-buildpackage build-essential dh-python python3-all
 
     - name: Configure Git for GBP
       run: |


### PR DESCRIPTION
This workflow builds the deb package, triggers the infra repo and publishes the package on packages.credativ.com 