### PR TITLE
fix: Fix nested pool evaluation which caused ProxLB to crash, caused by the proxmoxer library

### DIFF
--- a/.changelogs/1.1.12/31_fix_nested_pools_evaluation.yml
+++ b/.changelogs/1.1.12/31_fix_nested_pools_evaluation.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix nested pool evaluation which caused ProxLB to crash, caused by the proxmoxer library (@gyptazy). [#31]

--- a/proxlb/models/pools.py
+++ b/proxlb/models/pools.py
@@ -66,7 +66,12 @@ class Pools:
             pools['pools'][pool['poolid']]['members'] = []
 
             # Fetch pool details and collect member names
-            pool_details = proxmox_api.pools(pool['poolid']).get()
+            try:
+                pool_details = proxmox_api.pools(pool['poolid']).get()
+            except Exception as e:
+                logger.error(f"Error fetching pool details for pool {pool['poolid']}: {e}")
+                continue
+
             for member in pool_details.get("members", []):
 
                 # We might also have objects without the key "name", e.g. storage pools


### PR DESCRIPTION
fix: Fix nested pool evaluation which caused ProxLB to crash, caused by the proxmoxer library

Fixes: #31