### PR TITLE
Add packaging dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,11 @@ setup(
     url="https://github.com/gyptazy/ProxLB",
     packages=["proxlb", "proxlb.utils", "proxlb.models"],
     install_requires=[
-        "requests",
-        "urllib3",
+        "packaging",
         "proxmoxer",
         "pyyaml",
+        "requests",
+        "urllib3",
     ],
         data_files=[('/etc/systemd/system', ['service/proxlb.service']), ('/etc/proxlb/', ['config/proxlb_example.yaml'])],
 )


### PR DESCRIPTION
`requirements.txt` correctly mentions `packaging` as a dependency. An installation via `pip install proxlb` will need this dependency in `setup.py` where it is currently missing.