### PR TITLE
Increase version in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="proxlb",
-    version="1.1.12",
+    version="1.1.13",
     description="An advanced resource scheduler and load balancer for Proxmox clusters.",
     long_description="An advanced resource scheduler and load balancer for Proxmox clusters that also supports maintenance modes and affinity/anti-affinity rules.",
     author="Florian Paul Azim Hoberg",


### PR DESCRIPTION
I have missed this in https://github.com/credativ/ProxLB/pull/50. Instead of a whole new release `1.1.14`, I plan to build the `pypi` package based on this change.