### PR TITLE
Pushes images to docker.io

### DIFF
--- a/.github/workflows/30-pipeline-build-container.yml
+++ b/.github/workflows/30-pipeline-build-container.yml
@@ -77,6 +77,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -91,6 +97,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: |
+            ${{ steps.lowercase.outputs.result }}:${{ github.ref_name }}
+            ${{ steps.lowercase.outputs.result }}:latest
             ghcr.io/${{ steps.lowercase.outputs.result }}:${{ github.ref_name }}
             ghcr.io/${{ steps.lowercase.outputs.result }}:latest
           cache-from: type=gha

--- a/.github/workflows/30-pipeline-build-container.yml
+++ b/.github/workflows/30-pipeline-build-container.yml
@@ -78,6 +78,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -163,11 +163,13 @@ wget -O /etc/apt/keyrings/proxtools-archive-keyring.gpg https://packages.credati
 ### Container Images / Docker
 Using the ProxLB container images is straight forward and only requires you to mount the config file.
 
-Available images can be found at the GitHub [packages page](https://github.com/credativ/ProxLB/pkgs/container/proxlb).
+Available images can be found at the GitHub [packages page](https://github.com/credativ/ProxLB/pkgs/container/proxlb) or [Docker Hub](https://hub.docker.com/r/credativ/proxlb).
 
 ```bash
-# Pull the image
+# Pull the image from GHCR
 docker pull ghcr.io/credativ/proxlb:latest
+# or Docker Hub
+docker pull credativ/proxlb:latest
 # Download the config
 wget -O proxlb.yaml https://raw.githubusercontent.com/gyptazy/ProxLB/refs/heads/main/config/proxlb_example.yaml
 # Adjust the config to your needs
@@ -188,7 +190,7 @@ services:
       - ./proxlb.yaml:/etc/proxlb/proxlb.yaml:ro
 ```
 
-*Note: ProxLB container images are officially only available at ghcr.io/credativ/proxlb*
+*Note: ProxLB container images are officially only available at ghcr.io/credativ/proxlb or docker.io/credativ/proxlb*
 
 ### Source
 ProxLB can also easily be used from the provided sources - for traditional systems but also as a Docker/Podman container image.

--- a/docs/02_installation.md
+++ b/docs/02_installation.md
@@ -90,11 +90,13 @@ wget -O /etc/apt/keyrings/proxtools-archive-keyring.gpg https://packages.credati
 ### Container Images / Docker
 Using the ProxLB container images is straight forward and only requires you to mount the config file.
 
-Available images can be found at the GitHub [packages page](https://github.com/credativ/ProxLB/pkgs/container/proxlb).
+Available images can be found at the GitHub [packages page](https://github.com/credativ/ProxLB/pkgs/container/proxlb) or [Docker Hub](https://hub.docker.com/r/credativ/proxlb)..
 
 ```bash
-# Pull the image
+# Pull the image from GHCR
 docker pull ghcr.io/credativ/proxlb:latest
+# or Docker Hub
+docker pull credativ/proxlb:latest
 # Download the config
 wget -O proxlb.yaml https://raw.githubusercontent.com/gyptazy/ProxLB/refs/heads/main/config/proxlb_example.yaml
 # Adjust the config to your needs
@@ -103,7 +105,7 @@ vi proxlb.yaml
 docker run -it --rm -v $(pwd)/proxlb.yaml:/etc/proxlb/proxlb.yaml proxlb
 ```
 
-*Note: ProxLB container images are officially only available at ghcr.io/credativ/proxlb*
+*Note: ProxLB container images are officially only available at ghcr.io/credativ/proxlb or docker.io/credativ/proxlb*
 
 ### Source
 ProxLB can also easily be used from the provided sources - for traditional systems but also as a Docker/Podman container image.


### PR DESCRIPTION
We want to push images to docker.io in addition to GHCR as GHCR is IPv4 only.

Solves #48 and #55 