### PR TITLE
Add `cpu_overcommit` and `max_node_inflow` to `Config.Balancing`

### DIFF
--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -33,6 +33,8 @@ balancing:
   live: True
   with_local_disks: True
   with_conntrack_state: True
+  cpu_overcommit: 2.0                 # Maximum ratio of vCPUs to physical cores per node
+  max_node_inflow: 1                  # Maximum number of VMs that may be migrated onto any single node per run
   balance_types: ['vm', 'ct']         # 'vm' | 'ct'
   max_job_validation: 1800            # Maximum time (in seconds) a job validation may take
   memory_threshold: 75                # Optional: Maximum threshold (in percent) to trigger balancing actions

--- a/proxlb/utils/config_parser.py
+++ b/proxlb/utils/config_parser.py
@@ -103,12 +103,14 @@ class Config(BaseModel):
         balance_larger_guests_first: bool = False
         balance_types: list["Config.GuestType"] = []
         balanciness: int = 10
+        cpu_overcommit: float = 2.0
         cpu_threshold: Optional[int] = None
         enable: bool = False
         enforce_affinity: bool = False
         enforce_pinning: bool = False
         live: bool = True
         max_job_validation: int = 1800
+        max_node_inflow: Optional[int] = None
         memory_threshold: Optional[int] = None
         disk_threshold: Optional[int] = None
         method: "Config.Balancing.Resource" = Resource.Memory


### PR DESCRIPTION
Both are used by `proxlb-solver`