### PR TITLE
Fix/6 streaming migrations queue

### DIFF
--- a/.changelogs/1.1.14/6_parallel_jobs_issue_fix.yml
+++ b/.changelogs/1.1.14/6_parallel_jobs_issue_fix.yml
@@ -1,0 +1,7 @@
+changed:
+  - removes old chunk based balancing if running parallel jobs
+  - adds new streaming balancing with parallel job limit
+
+added:
+- Adds tests for streaming balancing with parallel job limit
+- Adds pyproject.toml configuration for test-specific linting rules

--- a/proxlb/main.py
+++ b/proxlb/main.py
@@ -29,7 +29,7 @@ from models.ha_rules import HaRules
 from utils.helper import Helper
 
 
-def main():
+def main() -> None:
     """
     ProxLB main function
     """
@@ -59,7 +59,7 @@ def main():
     proxmox_api = ProxmoxApi(proxlb_config)
 
     # Overwrite password after creating the API object
-    proxlb_config["proxmox_api"]["pass"] = "********"
+    proxlb_config["proxmox_api"]["pass"] = "********"  # noqa: S105
 
     while True:
 
@@ -104,16 +104,15 @@ def main():
             Helper.log_node_metrics(proxlb_data, init=False)
 
             # Perform balancing actions via Proxmox API
-            if proxlb_data["meta"]["balancing"].get("enable", False):
-                if not cli_args.dry_run:
-                    Balancing(proxmox_api, proxlb_data)
+            if proxlb_data["meta"]["balancing"].get("enable", False) and not cli_args.dry_run:
+                Balancing.balance(proxmox_api, proxlb_data)
 
         # Validate if the JSON output should be
         # printed to stdout
         Helper.print_json(proxlb_data, cli_args.json)
         # Validate daemon mode
         Helper.get_daemon_mode(proxlb_config)
-        logger.debug(f"Finished: __main__")
+        logger.debug("Finished: __main__")
 
 
 if __name__ == "__main__":

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -16,6 +16,7 @@ from utils.logger import SystemdLogger
 from pydantic import BaseModel
 from enum import Enum
 from typing import Dict, Any
+from utils.proxmox_api import ProxmoxApi
 
 logger = SystemdLogger()
 
@@ -65,7 +66,7 @@ class Balancing:
         retry_counter: int = 0
 
     @staticmethod
-    def balance(proxmox_api: Any, proxlb_data: Dict[str, Any]) -> bool:
+    def balance(proxmox_api: ProxmoxApi, proxlb_data: Dict[str, Any]) -> bool:
         """
         Initializes the Balancing class with the provided ProxLB data.
 
@@ -74,18 +75,8 @@ class Balancing:
             proxlb_data (dict): A dictionary containing data related to the ProxLB load balancing configuration.
         """
 
-        # Validate if balancing should be performed in parallel or sequentially.
-        # If parallel balancing is enabled, set the number of parallel jobs.
-        if not proxlb_data["meta"]["balancing"].get("parallel", False):
-            parallel_job_limit = 1
-            logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
-        else:
-            parallel_job_limit = proxlb_data["meta"]["balancing"].get("parallel_jobs", 5)
-            if parallel_job_limit < 1:
-                logger.warning("Balancing: Invalid parallel_jobs value. Parallel job limit must be at least 1. "
-                               + "Defaulting to 1.")
-                parallel_job_limit = 1
-            logger.debug(f"Balancing: Parallel balancing is enabled. Running with {parallel_job_limit} parallel jobs.")
+        logger.debug("Starting: balance.")
+        parallel_job_limit = Balancing.get_parallel_job_limit(proxlb_data["meta"]["balancing"])
 
         jobs_to_wait: list[Balancing.RebalancingJob] = []
         max_retries = proxlb_data["meta"]["balancing"].get("max_job_validation", 1800)
@@ -139,7 +130,7 @@ class Balancing:
         return True
 
     @staticmethod
-    def _exec_rebalancing(proxmox_api: Any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing(proxmox_api: ProxmoxApi, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a guest to a new node within the cluster based on the guest
         type. This function initiates the migration of a specified guest to a target node as
@@ -197,7 +188,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def _exec_rebalancing_vm(proxmox_api: Any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing_vm(proxmox_api: ProxmoxApi, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
         This function initiates the migration of a specified VM to a target node as part of the
@@ -246,7 +237,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def _exec_rebalancing_ct(proxmox_api: Any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing_ct(proxmox_api: ProxmoxApi, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a container (CT) to a new node within the cluster.
         This function initiates the migration of a specified CT to a target node as part of the
@@ -283,12 +274,17 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def _handle_job_status(proxmox_api: Any, job: RebalancingJob, jobs_to_wait: list[RebalancingJob], max_retries: int) -> bool:
+    def _handle_job_status(
+            proxmox_api: ProxmoxApi,
+            job: RebalancingJob,
+            jobs_to_wait: list[RebalancingJob],
+            max_retries: int
+    ) -> bool:
         """
         Checks the current status of a single in-flight migration job and updates jobs_to_wait.
 
         Args:
-            proxmox_api (object): The Proxmox API client instance.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
             job (RebalancingJob): The job whose status to check.
             jobs_to_wait (list): The list of currently in-flight jobs (mutated in place).
             max_retries (int): Maximum number of status checks before the job is considered timed out.
@@ -315,14 +311,15 @@ class Balancing:
         return False
 
     @staticmethod
-    def _get_rebalancing_job_status(proxmox_api: Any, job: RebalancingJob) -> BalancingStatus:
+    def _get_rebalancing_job_status(proxmox_api: ProxmoxApi, job: RebalancingJob) -> BalancingStatus:
         """
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
 
         Args:
-            proxmox_api (object): The Proxmox API client instance.
-            job (RebalancingJob): A RebalancingJob object containing information about the
-                        rebalancing job, including the guest name, current node, job ID, and retry counter.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            job (RebalancingJob):     A RebalancingJob object containing information about the
+                                      rebalancing job, including the guest name, current node,
+                                      job ID, and retry counter.
 
         Returns:
             BalancingStatus: The status of the rebalancing job.
@@ -349,7 +346,7 @@ class Balancing:
                          + "Proceeding with status check.")
 
         # Watch job id until it finalizes
-        # Note: Unsaved jobs are delivered in uppercase from Proxmox API
+        # Note: Unsaved jobs are delivered in uppercase from Proxmox Api
         # keep it defensive and provide a default value if anything changes in the future
         task_status = task.get("status", "").lower()
         if task_status == "running":
@@ -372,3 +369,25 @@ class Balancing:
             f"Balancing: Unexpected status for Job ID {job_id} (guest: {job.name}): "
             + f"{task.get('status', '')}. Please check manually."
         )
+
+    @staticmethod
+    def get_parallel_job_limit(proxlb_data_meta_balancing: Dict[str, Any]) -> int:
+        """
+        Retrieves the parallel job limit for balancing operations from the ProxLB configuration.
+
+        Returns:
+            int: The maximum number of parallel jobs allowed for balancing operations.
+        """
+        # Validate if balancing should be performed in parallel or sequentially.
+        # If parallel balancing is enabled, set the number of parallel jobs.
+        if not proxlb_data_meta_balancing.get("parallel", False):
+            limit = 1
+            logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
+        else:
+            limit = proxlb_data_meta_balancing.get("parallel_jobs", 5)
+            if limit < 1:
+                logger.warning("Balancing: Invalid parallel_jobs value. Parallel job limit must be at least 1. "
+                               + "Defaulting to 1.")
+                limit = 1
+            logger.debug(f"Balancing: Parallel balancing is enabled. Running with {limit} parallel jobs.")
+        return limit

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -12,9 +12,8 @@ __license__ = "GPL-3.0"
 
 import proxmoxer
 import time
-from itertools import islice
 from utils.logger import SystemdLogger
-from typing import Dict, Any
+from typing import Dict, Any, Enum
 
 logger = SystemdLogger()
 
@@ -39,12 +38,22 @@ class Balancing:
         Executes the rebalancing of a container (CT) to a new node within the cluster. Logs the migration
         process and handles exceptions.
 
-    get_rebalancing_job_status(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str, guest_current_node: str, job_id: int, retry_counter: int = 1) -> bool:
+    get_rebalancing_job_status(self, proxmox_api: any, job: Dict[str, Any]) -> bool:
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout
         is reached. Returns True if the job completed successfully, False otherwise.
     """
 
-    def __init__(self, proxmox_api: any, proxlb_data: Dict[str, Any]):
+    class BalancingStatus(Enum):
+        """
+        a helper class to passthe current status of an rebalöancing operation to the main thread when
+        running in parallel mode. This is required to update the queue.
+        """
+        RUNNING = "running"
+        FINISHED = "finished"
+        FAILED = "failed"
+
+    @staticmethod
+    def balance(proxmox_api: any, proxlb_data: Dict[str, Any]) -> bool:
         """
         Initializes the Balancing class with the provided ProxLB data.
 
@@ -52,37 +61,37 @@ class Balancing:
             proxmox_api (object): The Proxmox API client instance used to interact with the Proxmox cluster.
             proxlb_data (dict): A dictionary containing data related to the ProxLB load balancing configuration.
         """
-        def chunk_dict(data, size):
-            """
-            Splits a dictionary into chunks of a specified size.
-            Args:
-                data (dict): The dictionary to be split into chunks.
-                size (int): The size of each chunk.
-            Yields:
-                dict: A chunk of the original dictionary with the specified size.
-            """
-            logger.debug("Starting: chunk_dict.")
-            it = iter(data.items())
-            for chunk in range(0, len(data), size):
-                yield dict(islice(it, size))
 
         # Validate if balancing should be performed in parallel or sequentially.
         # If parallel balancing is enabled, set the number of parallel jobs.
-        parallel_jobs = proxlb_data["meta"]["balancing"].get("parallel_jobs", 5)
+        parallel_job_limit = proxlb_data["meta"]["balancing"].get("parallel_jobs", 5)
+
         if not proxlb_data["meta"]["balancing"].get("parallel", False):
-            parallel_jobs = 1
+            parallel_job_limit = 1
             logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
         else:
-            logger.debug(f"Balancing: Parallel balancing is enabled. Running with {parallel_jobs} parallel jobs.")
+            logger.debug(f"Balancing: Parallel balancing is enabled. Running with {parallel_job_limit} parallel jobs.")
 
-        for chunk in chunk_dict(proxlb_data["guests"], parallel_jobs):
-            jobs_to_wait = []
+        jobs_to_wait = []
+        max_retries = proxlb_data["meta"]["balancing"].get("max_job_validation", 1800)
+        item_iterator = iter(proxlb_data["guests"])
+        migration_done = False
+        error_occurred = False
 
-            for guest_name, guest_meta in chunk.items():
+        logger.debug("Starting: Balancing loop for guests.")
+        while True:
+            # get the next element to process from the guests dict.
+            element = next(item_iterator, None)
+            if not element:
+                logger.debug("Finished: no more guests to process.")
+                migration_done = True
+            else:
+                logger.debug(f"Balancing: Processing guest {element['name']} for potential rebalancing.")
+                guest_name = element['name']
+                guest_meta = element['meta']
 
                 # Check if the guest's target is not the same as the current node
                 if guest_meta["node_current"] != guest_meta["node_target"]:
-
                     # Check if the guest is not ignored and perform the balancing
                     # operation based on the guest type
                     if not guest_meta["ignore"]:
@@ -92,40 +101,81 @@ class Balancing:
                         if guest_meta["type"] == "vm":
                             if 'vm' in proxlb_data["meta"]["balancing"].get("balance_types", []):
                                 logger.debug(f"Balancing: Balancing for guest {guest_name} of type VM started.")
-                                job_id = self.exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
+                                job_id = Balancing.exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
                             else:
                                 logger.debug(
                                     f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                    "Guest is of type VM which is not included in allowed balancing types.")
-
+                                    f"Guest is of type VM which is not included in allowed balancing types.")
                         # CT Balancing
                         elif guest_meta["type"] == "ct":
                             if 'ct' in proxlb_data["meta"]["balancing"].get("balance_types", []):
                                 logger.debug(f"Balancing: Balancing for guest {guest_name} of type CT started.")
-                                job_id = self.exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
+                                job_id = Balancing.exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
                             else:
                                 logger.debug(
                                     f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                    "Guest is of type CT which is not included in allowed balancing types.")
-
+                                     "Guest is of type CT which is not included in allowed balancing types.")
                         # Just in case we get a new type of guest in the future
                         else:
-                            logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. Cannot proceed guest: {guest_meta['name']}.")
+                            logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. "+
+                                            f"Cannot proceed guest: {guest_meta['name']}.")
 
                         if job_id:
-                            jobs_to_wait.append((guest_name, guest_meta["node_current"], job_id))
-
+                            jobs_to_wait.append({
+                                'name': guest_name,
+                                'current_node': guest_meta["node_current"],
+                                'job_id': job_id,
+                                'retry_counter': 0,
+                            })
                     else:
                         logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
                 else:
-                    logger.debug(f"Balancing: Guest {guest_name} is already on the target node {guest_meta['node_target']} and will not be rebalanced.")
+                    logger.debug(f"Balancing: Guest {guest_name} is already on the target node "+
+                                 f"{guest_meta['node_target']} and will not be rebalanced.")
 
-            # Wait for all jobs in the current chunk to complete
-            for guest_name, node, job_id in jobs_to_wait:
-                if job_id:
-                    self.get_rebalancing_job_status(proxmox_api, proxlb_data, guest_name, node, job_id)
+            # Wait for at least one job in the current chunk to complete
+            while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
 
-    def exec_rebalancing_vm(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
+                for job in jobs_to_wait:
+                    if job.get('job_id', False):
+                        status = Balancing.get_rebalancing_job_status(proxmox_api, proxlb_data, job)
+                        if status == Balancing.BalancingStatus.FINISHED:
+                            jobs_to_wait.remove(job)
+                        elif status == Balancing.BalancingStatus.FAILED:
+                            logger.critical(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "+
+                                            "for migration went into an error! Please check manually.")
+                            jobs_to_wait.remove(job)
+                            error_occurred = True
+                        elif status == Balancing.BalancingStatus.RUNNING:
+                            job['retry_counter'] += 1
+
+                        if job['retry_counter'] >= max_retries:
+                            logger.warning(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) for migration "+
+                                           f"is still running. Retry counter: {job['retry_counter']} exceeded.")
+                            jobs_to_wait.remove(job)
+                            error_occurred = True
+
+                if len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
+                    time.sleep(5)  # Sleep for a short period before checking the job statuses again
+
+            if migration_done and len(jobs_to_wait) == 0:
+                logger.debug("Finished: Balancing loop for guests. All guests processed and migrations processed.")
+                break
+
+            # continue with the next guest if we are still below the parallel job limit and there are still guests
+            # to process
+
+        if error_occurred:
+            logger.warning("Balancing: Some migrations did not complete successfully. "+
+                           "Please check the logs and Proxmox cluster manually.")
+            logger.debug("Finished: get_rebalancing_job_status.")
+            return False
+
+        logger.info("Finished: Balancing loop for guests. All guests processed and migrations completed.")
+        return True
+
+    @staticmethod
+    def exec_rebalancing_vm(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
         This function initiates the migration of a specified VM to a target node as part of the
@@ -146,15 +196,8 @@ class Balancing:
         guest_node_target = proxlb_data["guests"][guest_name]["node_target"]
         job_id = None
 
-        if proxlb_data["meta"]["balancing"].get("live", True):
-            online_migration = 1
-        else:
-            online_migration = 0
-
-        if proxlb_data["meta"]["balancing"].get("with_local_disks", True):
-            with_local_disks = 1
-        else:
-            with_local_disks = 0
+        online_migration = 1 if proxlb_data["meta"]["balancing"].get("live", True) else 0
+        with_local_disks = 1 if proxlb_data["meta"]["balancing"].get("with_local_disks", True) else 0
 
         migration_options = {
             'target': guest_node_target,
@@ -168,16 +211,20 @@ class Balancing:
             migration_options['with-conntrack-state'] = 1
 
         try:
-            logger.info(f"Balancing: Starting to migrate VM guest {guest_name} from {guest_node_current} to {guest_node_target}.")
+            logger.info(f"Balancing: Starting to migrate VM guest {guest_name} "+
+                        f"from {guest_node_current} to {guest_node_target}.")
             job_id = proxmox_api.nodes(guest_node_current).qemu(guest_id).migrate().post(**migration_options)
         except proxmoxer.core.ResourceException as proxmox_api_error:
-            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors. Please check if resource is locked or similar.")
-            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors: {proxmox_api_error}")
+            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors. "+
+                            "Please check if resource is locked or similar.")
+            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type VM due to "+
+                         f"some Proxmox errors: {proxmox_api_error}")
 
         logger.debug("Finished: exec_rebalancing_vm.")
         return job_id
 
-    def exec_rebalancing_ct(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
+    @staticmethod
+    def exec_rebalancing_ct(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
         """
         Executes the rebalancing of a container (CT) to a new node within the cluster.
         This function initiates the migration of a specified CT to a target node as part of the
@@ -199,72 +246,75 @@ class Balancing:
         job_id = None
 
         try:
-            logger.info(f"Balancing: Starting to migrate CT guest {guest_name} from {guest_node_current} to {guest_node_target}.")
-            job_id = proxmox_api.nodes(guest_node_current).lxc(guest_id).migrate().post(target=guest_node_target, restart=1)
+            logger.info(f"Balancing: Starting to migrate CT guest {guest_name} from {guest_node_current} "+
+                        f"to {guest_node_target}.")
+            job_id = proxmox_api.nodes(guest_node_current).lxc(guest_id).migrate().post(
+                target=guest_node_target, restart=1
+                )
         except proxmoxer.core.ResourceException as proxmox_api_error:
-            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. Please check if resource is locked or similar.")
-            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors: {proxmox_api_error}")
+            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. "+
+                            "Please check if resource is locked or similar.")
+            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors:"+
+                         f" {proxmox_api_error}")
 
         logger.debug("Finished: exec_rebalancing_ct.")
         return job_id
 
-    def get_rebalancing_job_status(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str, guest_current_node: str, job_id: int, retry_counter: int = 1) -> bool:
+    @staticmethod
+    def get_rebalancing_job_status(proxmox_api: any, job: Dict[str, Any]) -> bool:
         """
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
 
         Args:
             proxmox_api (object): The Proxmox API client instance.
-            proxlb_data (dict): The ProxLB configuration data.
-            guest_name (str): The name of the guest (virtual machine) being rebalanced.
-            guest_current_node (str): The current node where the guest is running.
-            job_id (str): The ID of the rebalancing job to monitor.
-            retry_counter (int, optional): The current retry count. Defaults to 1.
+            job (dict): A dictionary containing information about the rebalancing job,
+                        including the guest name, current node, job ID, and retry counter.
 
         Returns:
             bool: True if the job completed successfully, False otherwise.
         """
         logger.debug("Starting: get_rebalancing_job_status.")
-        job = proxmox_api.nodes(guest_current_node).tasks(job_id).status().get()
+        task  = proxmox_api.nodes(job['current_node']).tasks(job['job_id']).status().get()
+        job_id = job['job_id']
+
 
         # Fetch actual migration job status if this got spawned by a HA job
-        if job["type"] == "hamigrate":
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) is a HA migration job. Fetching underlying migration job...")
+        if task["type"] == "hamigrate":
+            logger.debug(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "+
+                         "is a HA migration job. Fetching underlying migration job...")
             time.sleep(1)
             vm_id = int(job["id"])
-            qm_migrate_jobs = proxmox_api.nodes(guest_current_node).tasks.get(typefilter="qmigrate", vmid=vm_id, start=0, source="active", limit=1)
+            qm_migrate_jobs = proxmox_api.nodes(job['current_node']).tasks.get(
+                typefilter="qmigrate", vmid=vm_id, start=0, source="active", limit=1)
 
             if len(qm_migrate_jobs) > 0:
-                job = qm_migrate_jobs[0]
-                job_id = job["upid"]
-                logger.debug(f'Overwriting job polling for: ID {job_id} (guest: {guest_name}) by {job}')
+                task = qm_migrate_jobs[0]
+                job_id = task["upid"]
+                logger.debug(f'Overwriting job polling for: ID {job_id} (guest: {job["name"]}) by {job}')
         else:
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) is a standard migration job. Proceeding with status check.")
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) is a standard migration job."+
+                         "Proceeding with status check.")
 
         # Watch job id until it finalizes
         # Note: Unsaved jobs are delivered in uppercase from Proxmox API
-        if job.get("status", "").lower() == "running":
-            # Do not hammer the API while
-            # watching the job status
-            time.sleep(10)
-            retry_counter += 1
-
-            # Run recursion until we hit the soft-limit of maximum migration time for a guest
-            if retry_counter < proxlb_data["meta"]["balancing"].get("max_job_validation", 1800):
-                logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) for migration is still running... (Run: {retry_counter})")
-                self.get_rebalancing_job_status(proxmox_api, proxlb_data, guest_name, guest_current_node, job_id, retry_counter)
-            else:
-                logger.warning(f"Balancing: Job ID {job_id} (guest: {guest_name}) for migration took too long. Please check manually.")
-                logger.debug("Finished: get_rebalancing_job_status.")
-                return False
+        if task.get("status", "").lower() == "running":
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) for migration is still running...")
+            return Balancing.BalancingStatus.RUNNING
 
         # Validate job output for errors when finished
-        if job["status"] == "stopped":
+        if task.get("status", "").lower() == "stopped":
 
-            if job["exitstatus"] == "OK":
-                logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) was successfully.")
+            if task.get("exitstatus", "") == "OK":
+                logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) was successfully.")
                 logger.debug("Finished: get_rebalancing_job_status.")
-                return True
+                return Balancing.BalancingStatus.FINISHED
             else:
-                logger.critical(f"Balancing: Job ID {job_id} (guest: {guest_name}) went into an error! Please check manually.")
+                logger.critical(f"Balancing: Job ID {job_id} (guest: {job['name']}) went into an error! "+
+                                "Please check manually.")
                 logger.debug("Finished: get_rebalancing_job_status.")
-                return False
+                return Balancing.BalancingStatus.FAILED
+
+        raise AssertionError(
+            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job['name']}): " +
+            f"{task.get('status', '')}. Please check manually."
+            )

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -13,6 +13,7 @@ __license__ = "GPL-3.0"
 import proxmoxer
 import time
 from utils.logger import SystemdLogger
+from pydantic import BaseModel
 from enum import Enum
 from typing import Dict, Any
 
@@ -46,12 +47,25 @@ class Balancing:
 
     class BalancingStatus(Enum):
         """
-        a helper class to passthe current status of an rebalöancing operation to the main thread when
+        a helper class to passthe current status of an rebalancing operation to the main thread when
         running in parallel mode. This is required to update the queue.
         """
         RUNNING = "running"
         FINISHED = "finished"
         FAILED = "failed"
+
+    class RebalancingJob(BaseModel):
+        """
+        Type definition for rebalancing job information.
+        """
+        name: str
+        id: int
+        current_node: str
+        job_id: str
+        retry_counter: int = 0
+
+        def __getitem__(self, item: str) -> str | int:
+            return getattr(self, item)
 
     @staticmethod
     def balance(proxmox_api: any, proxlb_data: Dict[str, Any]) -> bool:
@@ -65,15 +79,14 @@ class Balancing:
 
         # Validate if balancing should be performed in parallel or sequentially.
         # If parallel balancing is enabled, set the number of parallel jobs.
-        parallel_job_limit = proxlb_data["meta"]["balancing"].get("parallel_jobs", 5)
-
         if not proxlb_data["meta"]["balancing"].get("parallel", False):
             parallel_job_limit = 1
             logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
         else:
+            parallel_job_limit = proxlb_data["meta"]["balancing"].get("parallel_jobs", 5)
             logger.debug(f"Balancing: Parallel balancing is enabled. Running with {parallel_job_limit} parallel jobs.")
 
-        jobs_to_wait = []
+        jobs_to_wait: list[Balancing.RebalancingJob] = []
         max_retries = proxlb_data["meta"]["balancing"].get("max_job_validation", 1800)
         item_iterator = iter(proxlb_data["guests"].items())
         migration_done = False
@@ -88,75 +101,38 @@ class Balancing:
                 migration_done = True
             else:
                 guest_name, guest_meta = element
-                logger.debug(f"Balancing: Processing guest {guest_name} for potential rebalancing.")
+                job_id = Balancing.exec_rebalancing(proxmox_api, proxlb_data, guest_name)
 
-                # Check if the guest's target is not the same as the current node
-                if guest_meta["node_current"] != guest_meta["node_target"]:
-                    # Check if the guest is not ignored and perform the balancing
-                    # operation based on the guest type
-                    if not guest_meta["ignore"]:
-                        job_id = None
-
-                        # VM Balancing
-                        if guest_meta["type"] == "vm":
-                            if 'vm' in proxlb_data["meta"]["balancing"].get("balance_types", []):
-                                logger.debug(f"Balancing: Balancing for guest {guest_name} of type VM started.")
-                                job_id = Balancing.exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
-                            else:
-                                logger.debug(
-                                    f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                    f"Guest is of type VM which is not included in allowed balancing types.")
-                        # CT Balancing
-                        elif guest_meta["type"] == "ct":
-                            if 'ct' in proxlb_data["meta"]["balancing"].get("balance_types", []):
-                                logger.debug(f"Balancing: Balancing for guest {guest_name} of type CT started.")
-                                job_id = Balancing.exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
-                            else:
-                                logger.debug(
-                                    f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                    + "Guest is of type CT which is not included in allowed balancing types.")
-                        # Just in case we get a new type of guest in the future
-                        else:
-                            logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. "
-                                            + f"Cannot proceed guest: {guest_meta['name']}.")
-
-                        if job_id:
-                            jobs_to_wait.append({
-                                'name': guest_name,
-                                'id': guest_meta["id"],
-                                'current_node': guest_meta["node_current"],
-                                'job_id': job_id,
-                                'retry_counter': 0,
-                            })
-                    else:
-                        logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
-                else:
-                    logger.debug(f"Balancing: Guest {guest_name} is already on the target node "
-                                 + f"{guest_meta['node_target']} and will not be rebalanced.")
+                if job_id is not None:
+                    jobs_to_wait.append(Balancing.RebalancingJob(
+                        name = guest_name,
+                        id = guest_meta['id'],
+                        current_node = guest_meta['node_current'],
+                        job_id = job_id
+                    ))
 
             # Wait for at least one job in the current chunk to complete
             while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
-
+                # work on a copy of the list to avoid issues when removing items while iterating
                 for job in list(jobs_to_wait):
-                    if job.get('job_id', False):
-                        status = Balancing.get_rebalancing_job_status(proxmox_api, job)
-                        if status == Balancing.BalancingStatus.FINISHED:
-                            jobs_to_wait.remove(job)
-                            continue
-                        elif status == Balancing.BalancingStatus.FAILED:
-                            logger.critical(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "
-                                            + "for migration went into an error! Please check manually.")
-                            jobs_to_wait.remove(job)
-                            error_occurred = True
-                            continue
-                        elif status == Balancing.BalancingStatus.RUNNING:
-                            job['retry_counter'] += 1
+                    status = Balancing.get_rebalancing_job_status(proxmox_api, job)
+                    if status == Balancing.BalancingStatus.FINISHED:
+                        jobs_to_wait.remove(job)
+                        continue
+                    elif status == Balancing.BalancingStatus.FAILED:
+                        logger.critical(f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
+                                        + "for migration went into an error! Please check manually.")
+                        jobs_to_wait.remove(job)
+                        error_occurred = True
+                        continue
+                    elif status == Balancing.BalancingStatus.RUNNING:
+                        job.retry_counter += 1
 
-                        if job['retry_counter'] >= max_retries:
-                            logger.warning(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) for migration "
-                                           + f"is still running. Retry counter: {job['retry_counter']} exceeded.")
-                            jobs_to_wait.remove(job)
-                            error_occurred = True
+                    if job.retry_counter >= max_retries:
+                        logger.warning(f"Balancing: Job ID {job.job_id} (guest: {job.name}) for migration "
+                                       + f"is still running. Retry counter: {job.retry_counter} exceeded.")
+                        jobs_to_wait.remove(job)
+                        error_occurred = True
 
                 if len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
                     time.sleep(5)  # Sleep for a short period before checking the job statuses again
@@ -178,7 +154,65 @@ class Balancing:
         return True
 
     @staticmethod
-    def exec_rebalancing_vm(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
+    def exec_rebalancing(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+        """
+        Executes the rebalancing of a guest to a new node within the cluster based on the guest
+        type. This function initiates the migration of a specified guest to a target node as
+        part of the load balancing process. It logs the migration process and handles any exceptions
+        that may occur during the migration.It returns the job_id the Proxmox VE API returned
+        when starting the migration, which can be used to monitor the migration status or
+        None if the migration could not be started.
+        Args:
+            proxmox_api (object): The Proxmox API client instance used to interact with the Proxmox cluster.
+            proxlb_data (dict): A dictionary containing data related to the ProxLB load balancing configuration.
+            guest_name (str): The name of the guest to be migrated.
+        Returns:
+            str | None: The job ID of the migration task if successful, None otherwise.
+        """
+        logger.debug("Starting: exec_rebalancing.")
+        guest_meta = proxlb_data["guests"][guest_name]
+        job_id = None
+
+        logger.debug(f"Balancing: Processing guest {guest_name} for potential rebalancing.")
+
+        # Check if the guest's target is not the same as the current node
+        if guest_meta["node_current"] != guest_meta["node_target"]:
+            # Check if the guest is not ignored and perform the balancing
+            # operation based on the guest type
+            if not guest_meta["ignore"]:
+                # VM Balancing
+                if guest_meta["type"] == "vm":
+                    if 'vm' in proxlb_data["meta"]["balancing"].get("balance_types", []):
+                        logger.debug(f"Balancing: Balancing for guest {guest_name} of type VM started.")
+                        job_id = Balancing.exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
+                    else:
+                        logger.debug(
+                            f"Balancing: Balancing for guest {guest_name} will not be performed. "
+                            f"Guest is of type VM which is not included in allowed balancing types.")
+                # CT Balancing
+                elif guest_meta["type"] == "ct":
+                    if 'ct' in proxlb_data["meta"]["balancing"].get("balance_types", []):
+                        logger.debug(f"Balancing: Balancing for guest {guest_name} of type CT started.")
+                        job_id = Balancing.exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
+                    else:
+                        logger.debug(
+                            f"Balancing: Balancing for guest {guest_name} will not be performed. "
+                            + "Guest is of type CT which is not included in allowed balancing types.")
+                # Just in case we get a new type of guest in the future
+                else:
+                    logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. "
+                            + f"Cannot proceed guest: {guest_meta['name']}.")
+            else:
+                logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
+        else:
+            logger.debug(f"Balancing: Guest {guest_name} is already on the target node "
+                         + f"{guest_meta['node_target']} and will not be rebalanced.")
+
+        logger.debug("Finished: exec_rebalancing.")
+        return job_id
+
+    @staticmethod
+    def exec_rebalancing_vm(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
         This function initiates the migration of a specified VM to a target node as part of the
@@ -191,7 +225,7 @@ class Balancing:
         Raises:
             proxmox_api.core.ResourceException: If an error occurs during the migration process.
         Returns:
-            None
+            str | None: The job ID of the migration task if successful, None otherwise.
         """
         logger.debug("Starting: exec_rebalancing_vm.")
         guest_id = proxlb_data["guests"][guest_name]["id"]
@@ -227,7 +261,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def exec_rebalancing_ct(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
+    def exec_rebalancing_ct(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a container (CT) to a new node within the cluster.
         This function initiates the migration of a specified CT to a target node as part of the
@@ -240,7 +274,7 @@ class Balancing:
         Raises:
             proxmox_api.core.ResourceException: If an error occurs during the migration process.
         Returns:
-            None
+            str | None: The job ID of the migration task if successful, None otherwise.
         """
         logger.debug("Starting: exec_rebalancing_ct.")
         guest_id = proxlb_data["guests"][guest_name]["id"]
@@ -264,59 +298,60 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def get_rebalancing_job_status(proxmox_api: any, job: Dict[str, Any]) -> Balancing.BalancingStatus:
+    def get_rebalancing_job_status(proxmox_api: any, job: RebalancingJob) -> BalancingStatus:
         """
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
 
         Args:
             proxmox_api (object): The Proxmox API client instance.
-            job (dict): A dictionary containing information about the rebalancing job,
-                        including the guest name, current node, job ID, and retry counter.
+            job (RebalancingJob): A RebalancingJob object containing information about the
+                        rebalancing job, including the guest name, current node, job ID, and retry counter.
 
         Returns:
-            bool: True if the job completed successfully, False otherwise.
+            BalancingStatus: The status of the rebalancing job.
         """
         logger.debug("Starting: get_rebalancing_job_status.")
-        task = proxmox_api.nodes(job['current_node']).tasks(job['job_id']).status().get()
-        job_id = job['job_id']
+        task = proxmox_api.nodes(job.current_node).tasks(job.job_id).status().get()
+        job_id = job.job_id
 
         # Fetch actual migration job status if this got spawned by a HA job
         if task["type"] == "hamigrate":
-            logger.debug(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "
+            logger.debug(f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
                          + "is a HA migration job. Fetching underlying migration job...")
             time.sleep(1)
-            vm_id = int(job["id"])
-            qm_migrate_jobs = proxmox_api.nodes(job['current_node']).tasks.get(
+            vm_id = job.id
+            qm_migrate_jobs = proxmox_api.nodes(job.current_node).tasks.get(
                 typefilter="qmigrate", vmid=vm_id, start=0, source="active", limit=1)
 
             if len(qm_migrate_jobs) > 0:
                 task = qm_migrate_jobs[0]
                 job_id = task["upid"]
-                logger.debug(f'Overwriting job polling for: ID {job_id} (guest: {job["name"]}) by {job}')
+                logger.debug(f'Overwriting job polling for: ID {job_id} (guest: {job.name}) by {job}')
         else:
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) is a standard migration job."
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) is a standard migration job."
                          + "Proceeding with status check.")
 
         # Watch job id until it finalizes
         # Note: Unsaved jobs are delivered in uppercase from Proxmox API
-        if task.get("status", "").lower() == "running":
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) for migration is still running...")
+        # keep it defensive and provide a default value if anything changes in the future
+        task_status = task.get("status", "").lower()
+        if task_status == "running":
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) for migration is still running...")
             return Balancing.BalancingStatus.RUNNING
 
         # Validate job output for errors when finished
-        if task.get("status", "").lower() == "stopped":
-
-            if task.get("exitstatus", "") == "OK":
-                logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) was successfully.")
+        if task_status == "stopped":
+            if task.get("exitstatus", "") == "OK":  # exitstatus is optional
+                logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) was successfully.")
                 logger.debug("Finished: get_rebalancing_job_status.")
                 return Balancing.BalancingStatus.FINISHED
             else:
-                logger.critical(f"Balancing: Job ID {job_id} (guest: {job['name']}) went into an error! "
+                logger.critical(f"Balancing: Job ID {job_id} (guest: {job.name}) went into an error! "
                                 + "Please check manually.")
                 logger.debug("Finished: get_rebalancing_job_status.")
                 return Balancing.BalancingStatus.FAILED
 
         raise AssertionError(
-            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job['name']}): "
+            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job.name}): "
             + f"{task.get('status', '')}. Please check manually."
         )

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -282,7 +282,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def _handle_job_status(proxmox_api: any, job: RebalancingJob, jobs_to_wait: list, max_retries: int) -> bool:
+    def _handle_job_status(proxmox_api: Any, job: RebalancingJob, jobs_to_wait: list[RebalancingJob], max_retries: int) -> bool:
         """
         Checks the current status of a single in-flight migration job and updates jobs_to_wait.
 

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -101,7 +101,7 @@ class Balancing:
                 migration_done = True
             else:
                 guest_name, guest_meta = element
-                job_id = Balancing.exec_rebalancing(proxmox_api, proxlb_data, guest_name)
+                job_id = Balancing._exec_rebalancing(proxmox_api, proxlb_data, guest_name)
 
                 if job_id is not None:
                     jobs_to_wait.append(Balancing.RebalancingJob(
@@ -115,23 +115,7 @@ class Balancing:
             while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
                 # work on a copy of the list to avoid issues when removing items while iterating
                 for job in list(jobs_to_wait):
-                    status = Balancing.get_rebalancing_job_status(proxmox_api, job)
-                    if status == Balancing.BalancingStatus.FINISHED:
-                        jobs_to_wait.remove(job)
-                        continue
-                    elif status == Balancing.BalancingStatus.FAILED:
-                        logger.critical(f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
-                                        + "for migration went into an error! Please check manually.")
-                        jobs_to_wait.remove(job)
-                        error_occurred = True
-                        continue
-                    elif status == Balancing.BalancingStatus.RUNNING:
-                        job.retry_counter += 1
-
-                    if job.retry_counter >= max_retries:
-                        logger.warning(f"Balancing: Job ID {job.job_id} (guest: {job.name}) for migration "
-                                       + f"is still running. Retry counter: {job.retry_counter} exceeded.")
-                        jobs_to_wait.remove(job)
+                    if Balancing._handle_job_status(proxmox_api, job, jobs_to_wait, max_retries):
                         error_occurred = True
 
                 if len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
@@ -154,7 +138,7 @@ class Balancing:
         return True
 
     @staticmethod
-    def exec_rebalancing(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a guest to a new node within the cluster based on the guest
         type. This function initiates the migration of a specified guest to a target node as
@@ -184,7 +168,7 @@ class Balancing:
                 if guest_meta["type"] == "vm":
                     if 'vm' in proxlb_data["meta"]["balancing"].get("balance_types", []):
                         logger.debug(f"Balancing: Balancing for guest {guest_name} of type VM started.")
-                        job_id = Balancing.exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
+                        job_id = Balancing._exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
                     else:
                         logger.debug(
                             f"Balancing: Balancing for guest {guest_name} will not be performed. "
@@ -193,7 +177,7 @@ class Balancing:
                 elif guest_meta["type"] == "ct":
                     if 'ct' in proxlb_data["meta"]["balancing"].get("balance_types", []):
                         logger.debug(f"Balancing: Balancing for guest {guest_name} of type CT started.")
-                        job_id = Balancing.exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
+                        job_id = Balancing._exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
                     else:
                         logger.debug(
                             f"Balancing: Balancing for guest {guest_name} will not be performed. "
@@ -212,7 +196,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def exec_rebalancing_vm(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing_vm(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
         This function initiates the migration of a specified VM to a target node as part of the
@@ -261,7 +245,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def exec_rebalancing_ct(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing_ct(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a container (CT) to a new node within the cluster.
         This function initiates the migration of a specified CT to a target node as part of the
@@ -298,7 +282,39 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def get_rebalancing_job_status(proxmox_api: any, job: RebalancingJob) -> BalancingStatus:
+    def _handle_job_status(proxmox_api: any, job: RebalancingJob, jobs_to_wait: list, max_retries: int) -> bool:
+        """
+        Checks the current status of a single in-flight migration job and updates jobs_to_wait.
+
+        Args:
+            proxmox_api (object): The Proxmox API client instance.
+            job (RebalancingJob): The job whose status to check.
+            jobs_to_wait (list): The list of currently in-flight jobs (mutated in place).
+            max_retries (int): Maximum number of status checks before the job is considered timed out.
+
+        Returns:
+            bool: True if the job entered an error state (FAILED or timed out), False otherwise.
+        """
+        status = Balancing._get_rebalancing_job_status(proxmox_api, job)
+        if status == Balancing.BalancingStatus.FINISHED:
+            jobs_to_wait.remove(job)
+            return False
+        if status == Balancing.BalancingStatus.FAILED:
+            logger.critical(f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
+                            + "for migration went into an error! Please check manually.")
+            jobs_to_wait.remove(job)
+            return True
+        # RUNNING
+        job.retry_counter += 1
+        if job.retry_counter >= max_retries:
+            logger.warning(f"Balancing: Job ID {job.job_id} (guest: {job.name}) for migration "
+                           + f"is still running. Retry counter: {job.retry_counter} exceeded.")
+            jobs_to_wait.remove(job)
+            return True
+        return False
+
+    @staticmethod
+    def _get_rebalancing_job_status(proxmox_api: any, job: RebalancingJob) -> BalancingStatus:
         """
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
 

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -64,9 +64,6 @@ class Balancing:
         job_id: str
         retry_counter: int = 0
 
-        def __getitem__(self, item: str) -> str | int:
-            return getattr(self, item)
-
     @staticmethod
     def balance(proxmox_api: Any, proxlb_data: Dict[str, Any]) -> bool:
         """

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -105,10 +105,10 @@ class Balancing:
 
                 if job_id is not None:
                     jobs_to_wait.append(Balancing.RebalancingJob(
-                        name = guest_name,
-                        id = guest_meta['id'],
-                        current_node = guest_meta['node_current'],
-                        job_id = job_id
+                        name=guest_name,
+                        id=guest_meta['id'],
+                        current_node=guest_meta['node_current'],
+                        job_id=job_id
                     ))
 
             # Wait for at least one job in the current chunk to complete
@@ -185,7 +185,7 @@ class Balancing:
                 # Just in case we get a new type of guest in the future
                 else:
                     logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. "
-                            + f"Cannot proceed guest: {guest_meta['name']}.")
+                                    + f"Cannot proceed guest: {guest_meta['name']}.")
             else:
                 logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
         else:

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -40,7 +40,7 @@ class Balancing:
         Executes the rebalancing of a container (CT) to a new node within the cluster. Logs the migration
         process and handles exceptions.
 
-    get_rebalancing_job_status(self, proxmox_api: any, job: Dict[str, Any]) -> bool:
+    get_rebalancing_job_status(self, proxmox_api: Any, job: Dict[str, Any]) -> bool:
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout
         is reached. Returns True if the job completed successfully, False otherwise.
     """

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -314,7 +314,7 @@ class Balancing:
         return False
 
     @staticmethod
-    def _get_rebalancing_job_status(proxmox_api: any, job: RebalancingJob) -> BalancingStatus:
+    def _get_rebalancing_job_status(proxmox_api: Any, job: RebalancingJob) -> BalancingStatus:
         """
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
 

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -114,11 +114,11 @@ class Balancing:
                             else:
                                 logger.debug(
                                     f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                     "Guest is of type CT which is not included in allowed balancing types.")
+                                    + "Guest is of type CT which is not included in allowed balancing types.")
                         # Just in case we get a new type of guest in the future
                         else:
-                            logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. "+
-                                            f"Cannot proceed guest: {guest_meta['name']}.")
+                            logger.critical(f"Balancing: Got unexpected guest type: {guest_meta['type']}. "
+                                            + f"Cannot proceed guest: {guest_meta['name']}.")
 
                         if job_id:
                             jobs_to_wait.append({
@@ -131,8 +131,8 @@ class Balancing:
                     else:
                         logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
                 else:
-                    logger.debug(f"Balancing: Guest {guest_name} is already on the target node "+
-                                 f"{guest_meta['node_target']} and will not be rebalanced.")
+                    logger.debug(f"Balancing: Guest {guest_name} is already on the target node "
+                                 + f"{guest_meta['node_target']} and will not be rebalanced.")
 
             # Wait for at least one job in the current chunk to complete
             while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
@@ -144,8 +144,8 @@ class Balancing:
                             jobs_to_wait.remove(job)
                             continue
                         elif status == Balancing.BalancingStatus.FAILED:
-                            logger.critical(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "+
-                                            "for migration went into an error! Please check manually.")
+                            logger.critical(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "
+                                            + "for migration went into an error! Please check manually.")
                             jobs_to_wait.remove(job)
                             error_occurred = True
                             continue
@@ -153,8 +153,8 @@ class Balancing:
                             job['retry_counter'] += 1
 
                         if job['retry_counter'] >= max_retries:
-                            logger.warning(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) for migration "+
-                                           f"is still running. Retry counter: {job['retry_counter']} exceeded.")
+                            logger.warning(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) for migration "
+                                           + f"is still running. Retry counter: {job['retry_counter']} exceeded.")
                             jobs_to_wait.remove(job)
                             error_occurred = True
 
@@ -169,8 +169,8 @@ class Balancing:
             # to process
 
         if error_occurred:
-            logger.warning("Balancing: Some migrations did not complete successfully. "+
-                           "Please check the logs and Proxmox cluster manually.")
+            logger.warning("Balancing: Some migrations did not complete successfully. "
+                           + "Please check the logs and Proxmox cluster manually.")
             logger.debug("Finished: get_rebalancing_job_status.")
             return False
 
@@ -214,14 +214,14 @@ class Balancing:
             migration_options['with-conntrack-state'] = 1
 
         try:
-            logger.info(f"Balancing: Starting to migrate VM guest {guest_name} "+
-                        f"from {guest_node_current} to {guest_node_target}.")
+            logger.info(f"Balancing: Starting to migrate VM guest {guest_name} "
+                        + f"from {guest_node_current} to {guest_node_target}.")
             job_id = proxmox_api.nodes(guest_node_current).qemu(guest_id).migrate().post(**migration_options)
         except proxmoxer.core.ResourceException as proxmox_api_error:
-            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors. "+
-                            "Please check if resource is locked or similar.")
-            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type VM due to "+
-                         f"some Proxmox errors: {proxmox_api_error}")
+            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors. "
+                            + "Please check if resource is locked or similar.")
+            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type VM due to "
+                         + f"some Proxmox errors: {proxmox_api_error}")
 
         logger.debug("Finished: exec_rebalancing_vm.")
         return job_id
@@ -249,16 +249,16 @@ class Balancing:
         job_id = None
 
         try:
-            logger.info(f"Balancing: Starting to migrate CT guest {guest_name} from {guest_node_current} "+
-                        f"to {guest_node_target}.")
+            logger.info(f"Balancing: Starting to migrate CT guest {guest_name} from {guest_node_current} "
+                        + f"to {guest_node_target}.")
             job_id = proxmox_api.nodes(guest_node_current).lxc(guest_id).migrate().post(
                 target=guest_node_target, restart=1
-                )
+            )
         except proxmoxer.core.ResourceException as proxmox_api_error:
-            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. "+
-                            "Please check if resource is locked or similar.")
-            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors:"+
-                         f" {proxmox_api_error}")
+            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. "
+                            + "Please check if resource is locked or similar.")
+            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors:"
+                         + f" {proxmox_api_error}")
 
         logger.debug("Finished: exec_rebalancing_ct.")
         return job_id
@@ -277,14 +277,13 @@ class Balancing:
             bool: True if the job completed successfully, False otherwise.
         """
         logger.debug("Starting: get_rebalancing_job_status.")
-        task  = proxmox_api.nodes(job['current_node']).tasks(job['job_id']).status().get()
+        task = proxmox_api.nodes(job['current_node']).tasks(job['job_id']).status().get()
         job_id = job['job_id']
-
 
         # Fetch actual migration job status if this got spawned by a HA job
         if task["type"] == "hamigrate":
-            logger.debug(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "+
-                         "is a HA migration job. Fetching underlying migration job...")
+            logger.debug(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "
+                         + "is a HA migration job. Fetching underlying migration job...")
             time.sleep(1)
             vm_id = int(job["id"])
             qm_migrate_jobs = proxmox_api.nodes(job['current_node']).tasks.get(
@@ -295,8 +294,8 @@ class Balancing:
                 job_id = task["upid"]
                 logger.debug(f'Overwriting job polling for: ID {job_id} (guest: {job["name"]}) by {job}')
         else:
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) is a standard migration job."+
-                         "Proceeding with status check.")
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {job['name']}) is a standard migration job."
+                         + "Proceeding with status check.")
 
         # Watch job id until it finalizes
         # Note: Unsaved jobs are delivered in uppercase from Proxmox API
@@ -312,12 +311,12 @@ class Balancing:
                 logger.debug("Finished: get_rebalancing_job_status.")
                 return Balancing.BalancingStatus.FINISHED
             else:
-                logger.critical(f"Balancing: Job ID {job_id} (guest: {job['name']}) went into an error! "+
-                                "Please check manually.")
+                logger.critical(f"Balancing: Job ID {job_id} (guest: {job['name']}) went into an error! "
+                                + "Please check manually.")
                 logger.debug("Finished: get_rebalancing_job_status.")
                 return Balancing.BalancingStatus.FAILED
 
         raise AssertionError(
-            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job['name']}): " +
-            f"{task.get('status', '')}. Please check manually."
-            )
+            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job['name']}): "
+            + f"{task.get('status', '')}. Please check manually."
+        )

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -13,7 +13,8 @@ __license__ = "GPL-3.0"
 import proxmoxer
 import time
 from utils.logger import SystemdLogger
-from typing import Dict, Any, Enum
+from enum import Enum
+from typing import Dict, Any
 
 logger = SystemdLogger()
 
@@ -74,7 +75,7 @@ class Balancing:
 
         jobs_to_wait = []
         max_retries = proxlb_data["meta"]["balancing"].get("max_job_validation", 1800)
-        item_iterator = iter(proxlb_data["guests"])
+        item_iterator = iter(proxlb_data["guests"].items())
         migration_done = False
         error_occurred = False
 
@@ -86,9 +87,8 @@ class Balancing:
                 logger.debug("Finished: no more guests to process.")
                 migration_done = True
             else:
-                logger.debug(f"Balancing: Processing guest {element['name']} for potential rebalancing.")
-                guest_name = element['name']
-                guest_meta = element['meta']
+                guest_name, guest_meta = element
+                logger.debug(f"Balancing: Processing guest {guest_name} for potential rebalancing.")
 
                 # Check if the guest's target is not the same as the current node
                 if guest_meta["node_current"] != guest_meta["node_target"]:
@@ -123,6 +123,7 @@ class Balancing:
                         if job_id:
                             jobs_to_wait.append({
                                 'name': guest_name,
+                                'id': guest_meta["id"],
                                 'current_node': guest_meta["node_current"],
                                 'job_id': job_id,
                                 'retry_counter': 0,
@@ -136,16 +137,18 @@ class Balancing:
             # Wait for at least one job in the current chunk to complete
             while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
 
-                for job in jobs_to_wait:
+                for job in list(jobs_to_wait):
                     if job.get('job_id', False):
-                        status = Balancing.get_rebalancing_job_status(proxmox_api, proxlb_data, job)
+                        status = Balancing.get_rebalancing_job_status(proxmox_api, job)
                         if status == Balancing.BalancingStatus.FINISHED:
                             jobs_to_wait.remove(job)
+                            continue
                         elif status == Balancing.BalancingStatus.FAILED:
                             logger.critical(f"Balancing: Job ID {job['job_id']} (guest: {job['name']}) "+
                                             "for migration went into an error! Please check manually.")
                             jobs_to_wait.remove(job)
                             error_occurred = True
+                            continue
                         elif status == Balancing.BalancingStatus.RUNNING:
                             job['retry_counter'] += 1
 

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -68,7 +68,7 @@ class Balancing:
             return getattr(self, item)
 
     @staticmethod
-    def balance(proxmox_api: any, proxlb_data: Dict[str, Any]) -> bool:
+    def balance(proxmox_api: Any, proxlb_data: Dict[str, Any]) -> bool:
         """
         Initializes the Balancing class with the provided ProxLB data.
 

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -138,7 +138,7 @@ class Balancing:
         return True
 
     @staticmethod
-    def _exec_rebalancing(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing(proxmox_api: Any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a guest to a new node within the cluster based on the guest
         type. This function initiates the migration of a specified guest to a target node as

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -264,7 +264,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def get_rebalancing_job_status(proxmox_api: any, job: Dict[str, Any]) -> bool:
+    def get_rebalancing_job_status(proxmox_api: any, job: Dict[str, Any]) -> Balancing.BalancingStatus:
         """
         Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
 

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -196,7 +196,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def _exec_rebalancing_vm(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing_vm(proxmox_api: Any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
         This function initiates the migration of a specified VM to a target node as part of the

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -245,7 +245,7 @@ class Balancing:
         return job_id
 
     @staticmethod
-    def _exec_rebalancing_ct(proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
+    def _exec_rebalancing_ct(proxmox_api: Any, proxlb_data: Dict[str, Any], guest_name: str) -> str | None:
         """
         Executes the rebalancing of a container (CT) to a new node within the cluster.
         This function initiates the migration of a specified CT to a target node as part of the

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -81,6 +81,10 @@ class Balancing:
             logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
         else:
             parallel_job_limit = proxlb_data["meta"]["balancing"].get("parallel_jobs", 5)
+            if parallel_job_limit < 1:
+                logger.warning("Balancing: Invalid parallel_jobs value. Parallel job limit must be at least 1. "
+                               + "Defaulting to 1.")
+                parallel_job_limit = 1
             logger.debug(f"Balancing: Parallel balancing is enabled. Running with {parallel_job_limit} parallel jobs.")
 
         jobs_to_wait: list[Balancing.RebalancingJob] = []

--- a/proxlb/models/tests/test_balancing_exec_rebalancing.py
+++ b/proxlb/models/tests/test_balancing_exec_rebalancing.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for Balancing._exec_rebalancing().
+
+These tests cover the routing and filtering logic inside exec_rebalancing():
+which guest types trigger a migration, which are silently skipped, and how
+unknown types are handled. The streaming queue machinery in balance() is
+tested separately in test_balancing_streaming_queue.py.
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+from unittest.mock import MagicMock, patch
+
+from models.balancing import Balancing
+
+
+def _proxlb_data(guest_name: str, guest: dict, balance_types: list[str] | None = None) -> dict:
+    return {
+        "meta": {
+            "balancing": {
+                "balance_types": balance_types if balance_types is not None else ["vm", "ct"],
+                "live": True,
+                "with_local_disks": True,
+            }
+        },
+        "guests": {guest_name: guest},
+    }
+
+
+def _vm(node_current: str = "node1", node_target: str = "node2", ignore: bool = False) -> dict:
+    return {"id": 101, "type": "vm", "node_current": node_current, "node_target": node_target, "ignore": ignore}
+
+
+def _ct(node_current: str = "node1", node_target: str = "node2", ignore: bool = False) -> dict:
+    return {"id": 201, "type": "ct", "node_current": node_current, "node_target": node_target, "ignore": ignore}
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_vm_in_balance_types_delegates_to_exec_rebalancing_vm(mock_ct, mock_vm) -> None:
+    """A VM guest whose type is listed in balance_types must trigger exec_rebalancing_vm."""
+    mock_vm.return_value = "UPID:node1:vm1"
+    proxlb_data = _proxlb_data("vm1", _vm(), balance_types=["vm"])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "vm1")
+
+    mock_vm.assert_called_once()
+    mock_ct.assert_not_called()
+    assert job_id == "UPID:node1:vm1"
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_vm_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
+    """A VM guest whose type is not listed in balance_types must be skipped (returns None)."""
+    proxlb_data = _proxlb_data("vm1", _vm(), balance_types=["ct"])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "vm1")
+
+    mock_vm.assert_not_called()
+    mock_ct.assert_not_called()
+    assert job_id is None
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_ct_in_balance_types_delegates_to_exec_rebalancing_ct(mock_ct, mock_vm) -> None:
+    """A CT guest whose type is listed in balance_types must trigger exec_rebalancing_ct."""
+    mock_ct.return_value = "UPID:node1:ct1"
+    proxlb_data = _proxlb_data("ct1", _ct(), balance_types=["ct"])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "ct1")
+
+    mock_ct.assert_called_once()
+    mock_vm.assert_not_called()
+    assert job_id == "UPID:node1:ct1"
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_ct_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
+    """A CT guest whose type is not listed in balance_types must be skipped (returns None)."""
+    proxlb_data = _proxlb_data("ct1", _ct(), balance_types=["vm"])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "ct1")
+
+    mock_ct.assert_not_called()
+    mock_vm.assert_not_called()
+    assert job_id is None
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_unknown_guest_type_returns_none(mock_ct, mock_vm) -> None:
+    """An unknown guest type must not trigger any migration and must return None."""
+    guest = {"id": 301, "type": "unknown", "node_current": "node1", "node_target": "node2",
+             "name": "odd1", "ignore": False}
+    proxlb_data = _proxlb_data("odd1", guest, balance_types=["vm", "ct"])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "odd1")
+
+    mock_vm.assert_not_called()
+    mock_ct.assert_not_called()
+    assert job_id is None

--- a/proxlb/models/tests/test_balancing_get_parallel_job_limit.py
+++ b/proxlb/models/tests/test_balancing_get_parallel_job_limit.py
@@ -1,0 +1,50 @@
+"""
+Unit tests for Balancing.get_parallel_job_limit().
+
+These tests verify that the static method correctly parses the balancing
+configuration and clamps invalid values, in particular the edge case where
+parallel mode is enabled but parallel_jobs is set to a value below 1 (which
+would otherwise cause an infinite loop in the streaming queue).
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+from models.balancing import Balancing
+
+
+def test_returns_1_when_parallel_key_is_absent() -> None:
+    """Missing parallel key must default to sequential mode (limit=1)."""
+    assert Balancing.get_parallel_job_limit({}) == 1
+
+
+def test_returns_1_when_parallel_is_false() -> None:
+    """Explicitly disabled parallel mode must return limit=1."""
+    assert Balancing.get_parallel_job_limit({"parallel": False}) == 1
+
+
+def test_returns_default_5_when_parallel_jobs_key_is_absent() -> None:
+    """parallel=True without parallel_jobs key must return the built-in default of 5."""
+    assert Balancing.get_parallel_job_limit({"parallel": True}) == 5
+
+
+def test_returns_configured_value_when_parallel_jobs_is_valid() -> None:
+    """A valid parallel_jobs value must be returned unchanged."""
+    assert Balancing.get_parallel_job_limit({"parallel": True, "parallel_jobs": 3}) == 3
+
+
+def test_returns_1_when_parallel_jobs_is_exactly_1() -> None:
+    """parallel_jobs=1 is the minimum valid value and must be accepted as-is."""
+    assert Balancing.get_parallel_job_limit({"parallel": True, "parallel_jobs": 1}) == 1
+
+
+def test_clamps_to_1_when_parallel_jobs_is_zero() -> None:
+    """parallel_jobs=0 is invalid; the method must clamp it to 1 to prevent an infinite loop."""
+    assert Balancing.get_parallel_job_limit({"parallel": True, "parallel_jobs": 0}) == 1
+
+
+def test_clamps_to_1_when_parallel_jobs_is_negative() -> None:
+    """Negative parallel_jobs is invalid; the method must clamp it to 1."""
+    assert Balancing.get_parallel_job_limit({"parallel": True, "parallel_jobs": -5}) == 1

--- a/proxlb/models/tests/test_balancing_streaming_queue.py
+++ b/proxlb/models/tests/test_balancing_streaming_queue.py
@@ -1,0 +1,226 @@
+"""
+Unit tests for the streaming migration queue in Balancing.balance().
+
+These tests verify that balance() correctly implements a continuous streaming
+queue: it keeps up to parallel_job_limit migrations in flight and immediately
+submits the next guest when a slot becomes free, rather than waiting for the
+entire current batch to finish.
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+from unittest.mock import MagicMock, patch
+
+from models.balancing import Balancing
+
+FINISHED = Balancing.BalancingStatus.FINISHED
+RUNNING = Balancing.BalancingStatus.RUNNING
+FAILED = Balancing.BalancingStatus.FAILED
+
+
+def _guest(guest_id: int, node_current: str, node_target: str, ignore: bool = False) -> dict:
+    return {
+        "id": guest_id,
+        "type": "vm",
+        "node_current": node_current,
+        "node_target": node_target,
+        "ignore": ignore,
+    }
+
+
+def _proxlb_data(guests: dict, parallel: bool = True, parallel_jobs: int = 2) -> dict:
+    return {
+        "meta": {
+            "balancing": {
+                "parallel": parallel,
+                "parallel_jobs": parallel_jobs,
+                "balance_types": ["vm"],
+                "live": True,
+                "with_local_disks": True,
+                "max_job_validation": 1800,
+            }
+        },
+        "guests": guests,
+    }
+
+
+@patch("models.balancing.time.sleep")
+@patch.object(Balancing, "get_rebalancing_job_status")
+@patch.object(Balancing, "exec_rebalancing_vm")
+def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_status, mock_sleep) ->None:
+    """Guests already on the target node must not trigger any migration."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node1"),
+        "vm2": _guest(102, "node2", "node2"),
+    })
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    mock_exec_vm.assert_not_called()
+    mock_get_status.assert_not_called()
+
+
+@patch("models.balancing.time.sleep")
+@patch.object(Balancing, "get_rebalancing_job_status")
+@patch.object(Balancing, "exec_rebalancing_vm")
+def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """Ignored guests must not be migrated even when their target node differs."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2", ignore=True),
+        "vm2": _guest(102, "node1", "node2", ignore=True),
+    })
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    mock_exec_vm.assert_not_called()
+
+
+@patch("models.balancing.time.sleep")
+@patch.object(Balancing, "get_rebalancing_job_status")
+@patch.object(Balancing, "exec_rebalancing_vm")
+def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_status, mock_sleep) ->None:
+    """With parallel=False only one migration must be in flight at any point in time."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2"),
+        "vm2": _guest(102, "node1", "node2"),
+        "vm3": _guest(103, "node1", "node2"),
+    }, parallel=False)
+
+    in_flight = [0]
+    max_concurrent = [0]
+
+    def tracking_exec(api, data, name) -> str:
+        in_flight[0] += 1
+        max_concurrent[0] = max(max_concurrent[0], in_flight[0])
+        return f"job-{name}"
+
+    def tracking_status(api, job) -> Balancing.BalancingStatus:
+        in_flight[0] -= 1
+        return Balancing.BalancingStatus.FINISHED
+
+    mock_exec_vm.side_effect = tracking_exec
+    mock_get_status.side_effect = tracking_status
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    assert mock_exec_vm.call_count == 3
+    assert max_concurrent[0] == 1, f"Expected at most 1 concurrent migration, got {max_concurrent[0]}"
+
+
+@patch("models.balancing.time.sleep")
+@patch.object(Balancing, "get_rebalancing_job_status")
+@patch.object(Balancing, "exec_rebalancing_vm")
+def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """
+    Core streaming guarantee: with parallel_job_limit=2 and 3 guests, the 3rd
+    migration must be submitted as soon as the 1st finishes — without waiting
+    for the 2nd to finish too.
+
+    Expected call_log order:
+        submit vm1 → submit vm2 → finish vm1 → submit vm3 → finish vm2 → finish vm3
+    """
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2"),
+        "vm2": _guest(102, "node1", "node2"),
+        "vm3": _guest(103, "node1", "node2"),
+    }, parallel=True, parallel_jobs=2)
+
+    call_log = []
+
+    def tracking_exec(api, data, name) -> str:
+        call_log.append(("submit", name))
+        return f"job-{name}"
+
+    # vm1 finishes on its first status check; vm2 needs one RUNNING round before finishing
+    status_sequences = {
+        "job-vm1": iter([Balancing.BalancingStatus.FINISHED]),
+        "job-vm2": iter([Balancing.BalancingStatus.RUNNING, Balancing.BalancingStatus.FINISHED]),
+        "job-vm3": iter([Balancing.BalancingStatus.FINISHED]),
+    }
+
+    def tracking_status(api, job) -> Balancing.BalancingStatus:
+        result = next(status_sequences[job["job_id"]])
+        if result == Balancing.BalancingStatus.FINISHED:
+            call_log.append(("finish", job["name"]))
+        return result
+
+    mock_exec_vm.side_effect = tracking_exec
+    mock_get_status.side_effect = tracking_status
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    assert mock_exec_vm.call_count == 3
+
+    idx_submit_vm3 = call_log.index(("submit", "vm3"))
+    idx_finish_vm1 = call_log.index(("finish", "vm1"))
+    idx_finish_vm2 = call_log.index(("finish", "vm2"))
+
+    assert idx_finish_vm1 < idx_submit_vm3, (
+        "vm3 must be submitted after vm1 finishes (slot freed), "
+        f"but call_log was: {call_log}"
+    )
+    assert idx_submit_vm3 < idx_finish_vm2, (
+        "vm3 must be submitted before vm2 finishes (streaming, not batching), "
+        f"but call_log was: {call_log}"
+    )
+
+
+@patch("models.balancing.time.sleep")
+@patch.object(Balancing, "get_rebalancing_job_status")
+@patch.object(Balancing, "exec_rebalancing_vm")
+def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """The number of in-flight migrations must never exceed parallel_job_limit."""
+    limit = 3
+    num_guests = 9
+    proxlb_data = _proxlb_data(
+        {f"vm{i}": _guest(100 + i, "node1", "node2") for i in range(num_guests)},
+        parallel=True,
+        parallel_jobs=limit,
+    )
+
+    in_flight = [0]
+    max_concurrent = [0]
+
+    def tracking_exec(api, data, name) -> str:
+        in_flight[0] += 1
+        max_concurrent[0] = max(max_concurrent[0], in_flight[0])
+        return f"job-{name}"
+
+    def tracking_status(api, job) -> Balancing.BalancingStatus:
+        in_flight[0] -= 1
+        return Balancing.BalancingStatus.FINISHED
+
+    mock_exec_vm.side_effect = tracking_exec
+    mock_get_status.side_effect = tracking_status
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    assert mock_exec_vm.call_count == num_guests
+    assert max_concurrent[0] <= limit, (
+        f"Concurrency limit violated: {max_concurrent[0]} migrations were in flight, limit is {limit}"
+    )
+
+
+@patch("models.balancing.time.sleep")
+@patch.object(Balancing, "get_rebalancing_job_status")
+@patch.object(Balancing, "exec_rebalancing_vm")
+def test_failed_migration_returns_false(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """A FAILED migration status must cause balance() to return False."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2"),
+    })
+
+    mock_exec_vm.return_value = "job-vm1"
+    mock_get_status.return_value = Balancing.BalancingStatus.FAILED
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is False

--- a/proxlb/models/tests/test_balancing_streaming_queue.py
+++ b/proxlb/models/tests/test_balancing_streaming_queue.py
@@ -145,9 +145,9 @@ def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, moc
     }
 
     def tracking_status(api, job) -> Balancing.BalancingStatus:
-        result = next(status_sequences[job["job_id"]])
+        result = next(status_sequences[job.job_id])
         if result == Balancing.BalancingStatus.FINISHED:
-            call_log.append(("finish", job["name"]))
+            call_log.append(("finish", job.name))
         return result
 
     mock_exec_vm.side_effect = tracking_exec

--- a/proxlb/models/tests/test_balancing_streaming_queue.py
+++ b/proxlb/models/tests/test_balancing_streaming_queue.py
@@ -48,8 +48,8 @@ def _proxlb_data(guests: dict, parallel: bool = True, parallel_jobs: int = 2) ->
 
 
 @patch("models.balancing.time.sleep")
-@patch.object(Balancing, "get_rebalancing_job_status")
-@patch.object(Balancing, "exec_rebalancing_vm")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
 def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """Guests already on the target node must not trigger any migration."""
     proxlb_data = _proxlb_data({
@@ -65,8 +65,8 @@ def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_statu
 
 
 @patch("models.balancing.time.sleep")
-@patch.object(Balancing, "get_rebalancing_job_status")
-@patch.object(Balancing, "exec_rebalancing_vm")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
 def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """Ignored guests must not be migrated even when their target node differs."""
     proxlb_data = _proxlb_data({
@@ -81,8 +81,8 @@ def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, moc
 
 
 @patch("models.balancing.time.sleep")
-@patch.object(Balancing, "get_rebalancing_job_status")
-@patch.object(Balancing, "exec_rebalancing_vm")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
 def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """With parallel=False only one migration must be in flight at any point in time."""
     proxlb_data = _proxlb_data({
@@ -114,8 +114,8 @@ def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_sta
 
 
 @patch("models.balancing.time.sleep")
-@patch.object(Balancing, "get_rebalancing_job_status")
-@patch.object(Balancing, "exec_rebalancing_vm")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
 def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """
     Core streaming guarantee: with parallel_job_limit=2 and 3 guests, the 3rd
@@ -173,8 +173,8 @@ def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, moc
 
 
 @patch("models.balancing.time.sleep")
-@patch.object(Balancing, "get_rebalancing_job_status")
-@patch.object(Balancing, "exec_rebalancing_vm")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
 def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """The number of in-flight migrations must never exceed parallel_job_limit."""
     limit = 3
@@ -210,8 +210,8 @@ def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status,
 
 
 @patch("models.balancing.time.sleep")
-@patch.object(Balancing, "get_rebalancing_job_status")
-@patch.object(Balancing, "exec_rebalancing_vm")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
 def test_failed_migration_returns_false(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """A FAILED migration status must cause balance() to return False."""
     proxlb_data = _proxlb_data({

--- a/proxlb/models/tests/test_balancing_streaming_queue.py
+++ b/proxlb/models/tests/test_balancing_streaming_queue.py
@@ -50,7 +50,7 @@ def _proxlb_data(guests: dict, parallel: bool = True, parallel_jobs: int = 2) ->
 @patch("models.balancing.time.sleep")
 @patch.object(Balancing, "get_rebalancing_job_status")
 @patch.object(Balancing, "exec_rebalancing_vm")
-def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_status, mock_sleep) ->None:
+def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """Guests already on the target node must not trigger any migration."""
     proxlb_data = _proxlb_data({
         "vm1": _guest(101, "node1", "node1"),
@@ -83,7 +83,7 @@ def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, moc
 @patch("models.balancing.time.sleep")
 @patch.object(Balancing, "get_rebalancing_job_status")
 @patch.object(Balancing, "exec_rebalancing_vm")
-def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_status, mock_sleep) ->None:
+def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_status, mock_sleep) -> None:
     """With parallel=False only one migration must be in flight at any point in time."""
     proxlb_data = _proxlb_data({
         "vm1": _guest(101, "node1", "node2"),

--- a/proxlb/models/tests/test_calculations_get_most_free_node.py
+++ b/proxlb/models/tests/test_calculations_get_most_free_node.py
@@ -8,8 +8,6 @@ __copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
 __license__ = "GPL-3.0"
 
 
-import pytest
-
 from models.calculations import Calculations
 
 
@@ -33,8 +31,7 @@ def test_min_usage_with_empty_nodes() -> None:
     """
     Test the case where there are no nodes available (empty nodes dict).
     """
-    method = "cpu"
-    mode = "avg"
+
     proxlb_data = {
         "nodes": {},
         "meta": {"balancing": {}},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.ruff]
+target-version = "py310"
+line-length = 160
+
+[tool.ruff.lint]
+
+select = [
+    "E",                # pycodestyle errors
+    "W",                # pycodestyle warnings
+    "F",                   # Pyflakes (logic errors)
+    "B",             # flake8-bugbear (design issues & risky constructs)
+    "S",              # flake8-bandit (security checks)
+    "C4",                           # flake8-comprehensions (better list/dict handling)
+    "SIM",          # flake8-simplify (code simplification)
+    "ARG",  # flake8-unused-arguments
+    "PTH",       # flake8-use-pathlib (safer path operations)
+    "TRY",              # tryceratops (best practices for exceptions)
+    "PL",                           # Pylint (general code quality)
+    "RUF",      # Ruff-specific rules
+    "ANN",       # flake8-annotations
+    "PYI",               # flake8-pyi (type hints)
+    "FA", # flake8-future-annotations
+]
+ignore = []
+
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]
+
+[tool.ruff.lint.pylint]
+max-args = 5
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/*.py" = ["S101", "ARG001", "ANN001","PLR2004",]  # allow assert and print in tests

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
         "requests",
         "urllib3",
     ],
-        data_files=[('/etc/systemd/system', ['service/proxlb.service']), ('/etc/proxlb/', ['config/proxlb_example.yaml'])],
+    data_files=[('/etc/systemd/system', ['service/proxlb.service']), ('/etc/proxlb/', ['config/proxlb_example.yaml'])],
 )


### PR DESCRIPTION
This addresses and closes #6 and gives us a stream of current migrating VMs not just chucks. Please test intensively as I dont have too much test environment here around.

As we spoke, there is a pyproject.toml to support better liniting which should have been in place before, at least, I was expecting this. If you want to have this for version 2 please let me know.  