### PR TITLE
Add CA bundle environment variable to proxlb service

### DIFF
--- a/service/proxlb.service
+++ b/service/proxlb.service
@@ -4,6 +4,7 @@ After=network-online.target pveproxy.service
 Wants=network-online.target pveproxy.service
 
 [Service]
+Environment="REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 ExecStart=python3 -m proxlb -c /etc/proxlb/proxlb.yaml
 User=plb
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Enables support for third-party Root Certificate Authorities (CAs). This is specifically intended for environments where Proxmox nodes are secured using internal or private CAs rather than a publicly trusted CA (such as Let's Encrypt).

Without this change, API requests to Proxmox nodes using self-signed or internal certificates may fail due to SSL verification errors.

I am submitting this for review as I am unsure if you would prefer to implement this directly within the service or handle it via a documentation entry for internal CAs.