### PR TITLE
feature: Add static maintenance window support

### DIFF
--- a/.changelogs/2.1.0/42_add_maintenance_window_support.yml
+++ b/.changelogs/2.1.0/42_add_maintenance_window_support.yml
@@ -1,0 +1,2 @@
+added:
+- Add dynamic maintenance window support for nodes [#42]

--- a/.changelogs/2.1.0/release_meta.yml
+++ b/.changelogs/2.1.0/release_meta.yml
@@ -1,0 +1,1 @@
+date: TBD

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ The following options can be set in the configuration file `proxlb.yaml`:
 |  | wait_time |  | 1 | `Int` | How many seconds should be waited before performing another connection attempt to the API host. |
 | `proxmox_cluster` |  |  |  |  |  |
 |  | maintenance_nodes |  | ['virt66.example.com'] | `List` | A list of Proxmox nodes that are defined to be in a maintenance. (must be the same node names as used within the cluster) |
+|  | maintenance_nodes_schedule |  |  | `Dict` | A weekly schedule that temporarily adds nodes to `maintenance_nodes` during runtime. |
 |  | ignore_nodes |  | [] | `List` | A list of Proxmox nodes that are defined to be ignored. |
 |  | overprovisioning |  | False | `Bool` | Avoids balancing when nodes would become overprovisioned. |
 | `balancing` |  |  |  |  |  |
@@ -336,6 +337,12 @@ proxmox_api:
 
 proxmox_cluster:
   maintenance_nodes: ['virt66.example.com']
+  maintenance_nodes_schedule:
+    duration: 3
+    pre-migration: 10
+    schedules:
+      virt77.example.com:
+        - 'Monday, 8:00'
   ignore_nodes: []
   overprovisioning: True
 
@@ -537,6 +544,17 @@ proxmox_cluster:
   maintenance_nodes: ['virt66.example.com']
 ```
 Afterwards, all guest objects will be moved to other nodes in the cluster by ensuring the best balancing.
+
+Maintenance mode can also be scheduled. Scheduled nodes are added during each runtime cycle and removed automatically when the active window ends. `duration` is counted in hours from the configured start time, while `pre-migration` starts maintenance mode that many minutes earlier.
+```yaml
+proxmox_cluster:
+  maintenance_nodes_schedule:
+    duration: 3
+    pre-migration: 10
+    schedules:
+      virt77.example.com:
+        - 'Monday, 8:00'
+```
 
 ## Misc
 ### Bugs

--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -13,6 +13,12 @@ proxmox_api:
 
 proxmox_cluster:
   maintenance_nodes: ['virt66.example.com']
+  maintenance_nodes_schedule:
+    duration: 3                       # Duration in hours after the configured schedule start
+    pre-migration: 10                 # Start maintenance this many minutes before the configured schedule
+    schedules:
+      virt77.example.com:
+        - 'Monday, 8:00'
   ignore_nodes: []
   overprovisioning: True
 

--- a/docs/03_configuration.md
+++ b/docs/03_configuration.md
@@ -265,6 +265,20 @@ The maintenance_nodes key must be defined as a list, even if it only includes a 
 
 This feature is particularly useful during planned maintenance, upgrades, or troubleshooting, ensuring that services continue to run with minimal disruption while the specified node is being worked on.
 
+Maintenance mode can also be scheduled with `maintenance_nodes_schedule` under `proxmox_cluster`. ProxLB evaluates the schedule during each runtime cycle, adds matching nodes to the runtime maintenance list, and removes them again once the active window is over.
+
+```yaml
+proxmox_cluster:
+  maintenance_nodes_schedule:
+    duration: 3       # Hours after the configured start time
+    pre-migration: 10 # Minutes before the configured start time
+    schedules:
+      virt77.example.com:
+        - 'Monday, 8:00'
+```
+
+In this example, `virt77.example.com` enters maintenance mode every Monday at 07:50 and leaves it at 11:00. Schedule entries use the format `Weekday, H:MM` or `Weekday, HH:MM`.
+
 ## 10. Balancing Methods
 ProxLB provides multiple balancing modes that define *how* resources are evaluated and compared during cluster balancing.
 Each mode reflects a different strategy for determining load and distributing guests (VMs or containers) between nodes.

--- a/helm/proxlb/values.yaml
+++ b/helm/proxlb/values.yaml
@@ -32,6 +32,10 @@ configmap:
       timeout: 10
     proxmox_cluster:
       maintenance_nodes: [ ]
+      maintenance_nodes_schedule:
+        duration: 3
+        pre-migration: 10
+        schedules: { }
       ignore_nodes: [ ]
       overprovisioning: True
     balancing:

--- a/proxlb/__main__.py
+++ b/proxlb/__main__.py
@@ -90,6 +90,7 @@ while True:
         Helper.proxlb_reload = False
 
     # Get all required objects from the Proxmox cluster
+    Helper.apply_maintenance_nodes_schedule(proxlb_config)
     nodes = Nodes.get_nodes(proxmox_api, proxlb_config)
     meta = Features.validate_any_non_pve9_node(proxlb_config, nodes)
     pools = Pools.get_pools(proxmox_api)

--- a/proxlb/utils/config_parser.py
+++ b/proxlb/utils/config_parser.py
@@ -16,8 +16,8 @@ try:
 except ImportError:
     PYYAML_PRESENT = False
 from enum import StrEnum
-from typing import Optional, assert_never
-from pydantic import BaseModel, Field, ValidationError
+from typing import Any, Optional, assert_never
+from pydantic import BaseModel, Field, PrivateAttr, ValidationError
 from pathlib import Path
 from proxlb.utils.logger import SystemdLogger
 
@@ -58,9 +58,23 @@ class Config(BaseModel):
         wait_time: int = 1
 
     class ProxmoxCluster(BaseModel):
+        class MaintenanceNodesSchedule(BaseModel):
+            duration: int = Field(default=0, ge=0)
+            pre_migration: int = Field(default=0, alias="pre-migration", ge=0)
+            schedules: dict[str, list[str]] = Field(default_factory=dict)
+
+        _maintenance_nodes_static: list[str] = PrivateAttr(default_factory=list)
+
         ignore_nodes: list[str] = []
         maintenance_nodes: list[str] = []
+        maintenance_nodes_schedule: MaintenanceNodesSchedule = Field(default_factory=MaintenanceNodesSchedule)
         overprovisioning: bool = False
+
+        def model_post_init(self, __context: Any) -> None:
+            self._maintenance_nodes_static = list(dict.fromkeys(self.maintenance_nodes))
+
+        def static_maintenance_nodes(self) -> list[str]:
+            return list(self._maintenance_nodes_static)
 
     class Balancing(BaseModel):
         class Resource(StrEnum):

--- a/proxlb/utils/helper.py
+++ b/proxlb/utils/helper.py
@@ -14,6 +14,7 @@ import re
 import socket
 import sys
 import time
+from datetime import datetime, timedelta, time as datetime_time
 from proxlb.utils import version
 from proxlb.utils.config_parser import Config
 from proxlb.utils.logger import SystemdLogger
@@ -48,6 +49,15 @@ class Helper:
             Checks if the daemon mode is active and handles the scheduling accordingly.
     """
     proxlb_reload = False
+    weekdays = {
+        "monday": 0,
+        "tuesday": 1,
+        "wednesday": 2,
+        "thursday": 3,
+        "friday": 4,
+        "saturday": 5,
+        "sunday": 6,
+    }
 
     def __init__(self) -> None:
         """
@@ -140,6 +150,84 @@ class Helper:
             sys.exit(0)
 
         logger.debug("Finished: get_daemon_mode.")
+
+    @staticmethod
+    def apply_maintenance_nodes_schedule(proxlb_config: Config, now: Optional[datetime] = None) -> None:
+        """
+        Adds nodes with active maintenance schedules to the runtime maintenance list.
+
+        The configured static maintenance list is kept as the source of truth. This
+        allows scheduled entries to be removed automatically after their window ends.
+        """
+        logger.debug("Starting: apply_maintenance_nodes_schedule.")
+        now = now or datetime.now()
+        schedule_config = proxlb_config.proxmox_cluster.maintenance_nodes_schedule
+        maintenance_nodes = proxlb_config.proxmox_cluster.static_maintenance_nodes()
+
+        if not schedule_config.schedules:
+            proxlb_config.proxmox_cluster.maintenance_nodes = maintenance_nodes
+            logger.debug("No maintenance_nodes_schedule configured.")
+            logger.debug("Finished: apply_maintenance_nodes_schedule.")
+            return
+
+        scheduled_nodes: list[str] = []
+        for node_name, schedules in schedule_config.schedules.items():
+            for schedule in schedules:
+                if Helper.is_maintenance_schedule_active(
+                    schedule,
+                    schedule_config.duration,
+                    schedule_config.pre_migration,
+                    now,
+                ):
+                    scheduled_nodes.append(node_name)
+                    logger.info(f"Node: {node_name} has been set to maintenance mode (by ProxLB schedule).")
+                    break
+
+        proxlb_config.proxmox_cluster.maintenance_nodes = list(dict.fromkeys(maintenance_nodes + scheduled_nodes))
+        logger.debug(f"Runtime maintenance nodes: {proxlb_config.proxmox_cluster.maintenance_nodes}")
+        logger.debug("Finished: apply_maintenance_nodes_schedule.")
+
+    @staticmethod
+    def is_maintenance_schedule_active(schedule: str, duration_hours: int, pre_migration_minutes: int, now: datetime) -> bool:
+        """
+        Returns True when now is inside a weekly maintenance schedule window.
+        """
+        parsed_schedule = Helper.parse_maintenance_schedule(schedule)
+        if not parsed_schedule:
+            return False
+
+        weekday, schedule_time = parsed_schedule
+        weekday_delta = weekday - now.weekday()
+        schedule_date = (now + timedelta(days=weekday_delta)).date()
+
+        for week_offset in (-1, 0, 1):
+            schedule_start = datetime.combine(
+                schedule_date + timedelta(days=week_offset * 7),
+                schedule_time,
+            )
+            window_start = schedule_start - timedelta(minutes=pre_migration_minutes)
+            window_end = schedule_start + timedelta(hours=duration_hours)
+
+            if window_start <= now < window_end:
+                return True
+
+        return False
+
+    @staticmethod
+    def parse_maintenance_schedule(schedule: str) -> Optional[tuple[int, datetime_time]]:
+        """
+        Parses weekly maintenance schedules in the format 'Monday, 8:00'.
+        """
+        try:
+            weekday_name, time_config = [part.strip() for part in schedule.split(",", 1)]
+            hour_config, minute_config = time_config.split(":", 1)
+            weekday = Helper.weekdays[weekday_name.lower()]
+            schedule_time = datetime_time(hour=int(hour_config), minute=int(minute_config))
+        except (KeyError, TypeError, ValueError):
+            logger.warning(f"Ignoring invalid maintenance schedule '{schedule}'. Expected format: Monday, 8:00")
+            return None
+
+        return weekday, schedule_time
 
     @staticmethod
     def get_service_delay(proxlb_config: Config) -> None:

--- a/tests/test_maintenance_nodes_schedule.py
+++ b/tests/test_maintenance_nodes_schedule.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+
+from proxlb.utils.config_parser import Config
+from proxlb.utils.helper import Helper
+
+
+def _schedule(
+    duration: int,
+    pre_migration: int,
+    schedules: dict[str, list[str]],
+) -> Config.ProxmoxCluster.MaintenanceNodesSchedule:
+    return Config.ProxmoxCluster.MaintenanceNodesSchedule.model_validate(
+        {
+            "duration": duration,
+            "pre-migration": pre_migration,
+            "schedules": schedules,
+        }
+    )
+
+
+def _config() -> Config:
+    return Config(
+        proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),
+        proxmox_cluster=Config.ProxmoxCluster(
+            maintenance_nodes=["static-node"],
+            maintenance_nodes_schedule=_schedule(
+                duration=3,
+                pre_migration=10,
+                schedules={
+                    "scheduled-node": ["Monday, 8:00"],
+                },
+            ),
+        ),
+    )
+
+
+def test_maintenance_schedule_adds_node_before_start() -> None:
+    proxlb_config = _config()
+
+    Helper.apply_maintenance_nodes_schedule(
+        proxlb_config,
+        now=datetime(2026, 5, 4, 7, 55),
+    )
+
+    assert proxlb_config.proxmox_cluster.maintenance_nodes == [
+        "static-node",
+        "scheduled-node",
+    ]
+
+
+def test_maintenance_schedule_removes_node_after_duration() -> None:
+    proxlb_config = _config()
+
+    Helper.apply_maintenance_nodes_schedule(
+        proxlb_config,
+        now=datetime(2026, 5, 4, 7, 55),
+    )
+    Helper.apply_maintenance_nodes_schedule(
+        proxlb_config,
+        now=datetime(2026, 5, 4, 11, 0),
+    )
+
+    assert proxlb_config.proxmox_cluster.maintenance_nodes == ["static-node"]
+
+
+def test_maintenance_schedule_handles_pre_migration_across_week_boundary() -> None:
+    proxlb_config = Config(
+        proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),
+        proxmox_cluster=Config.ProxmoxCluster(
+            maintenance_nodes_schedule=_schedule(
+                duration=1,
+                pre_migration=10,
+                schedules={
+                    "scheduled-node": ["Monday, 0:00"],
+                },
+            ),
+        ),
+    )
+
+    Helper.apply_maintenance_nodes_schedule(
+        proxlb_config,
+        now=datetime(2026, 5, 3, 23, 55),
+    )
+
+    assert proxlb_config.proxmox_cluster.maintenance_nodes == ["scheduled-node"]
+
+
+def test_invalid_maintenance_schedule_is_ignored() -> None:
+    proxlb_config = Config(
+        proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),
+        proxmox_cluster=Config.ProxmoxCluster(
+            maintenance_nodes=["static-node"],
+            maintenance_nodes_schedule=_schedule(
+                duration=1,
+                pre_migration=10,
+                schedules={
+                    "scheduled-node": ["Moonday, 8:00"],
+                },
+            ),
+        ),
+    )
+
+    Helper.apply_maintenance_nodes_schedule(
+        proxlb_config,
+        now=datetime(2026, 5, 4, 7, 55),
+    )
+
+    assert proxlb_config.proxmox_cluster.maintenance_nodes == ["static-node"]


### PR DESCRIPTION
feature: Add static maintenance window support
  - Allow operators to define static time frames where nodes are being set to maintenance to avoid from being used and to clear workloads.

### Example
```
  maintenance_nodes_schedule:
    duration: 3
    pre-migration: 10
    schedules:
      virt77.example.com:
        - 'Monday, 8:00'
```

Fixes: #42