### PR TITLE
Fix/6 streaming migrations queue for 2.0

### DIFF
--- a/.changelogs/2.1.0/6-fix-streaming-migration-queue.yml
+++ b/.changelogs/2.1.0/6-fix-streaming-migration-queue.yml
@@ -1,0 +1,8 @@
+fixed:
+- Fix streaming migration queue in the balancing algorithm to correctly track in-flight
+  migration jobs up to the configured parallel job limit
+- Resolve an issue where the queue could stall or exit prematurely when all guests were
+  dispatched but not all migrations had finished
+- Ensure failed migrations are properly detected and reported instead of being silently
+  skipped during parallel execution
+- added some pytest tasks

--- a/proxlb/__main__.py
+++ b/proxlb/__main__.py
@@ -152,10 +152,10 @@ while True:
                         logger.warning(
                             f"[solver] active execution failed, falling back to "
                             f"ProxLB plan: {exc}")
-                        Balancing(proxmox_api, proxlb_data)
+                        Balancing.balance(proxmox_api, proxlb_data)
                     reinstall_sigint()
                 else:
-                    Balancing(proxmox_api, proxlb_data)
+                    Balancing.balance(proxmox_api, proxlb_data)
 
         # Record whether balancing was executed or skipped (dry-run).
         if _run_file is not None:

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -120,10 +120,10 @@ class Balancing:
 
         while jobs_to_wait:
             if Balancing._check_jobs_and_update(proxmox_api, jobs_to_wait, max_retries):
-              error_occurred = True
+                error_occurred = True
             if jobs_to_wait:
-              time.sleep(5)
-        
+                time.sleep(5)
+
         if error_occurred:
             logger.warning(
                 "Balancing: Some migrations did not complete successfully. "
@@ -291,7 +291,7 @@ class Balancing:
             if Balancing._handle_job_status(proxmox_api, job, jobs_to_wait, max_retries):
                 error_occurred = True
         return error_occurred
-    
+
     @staticmethod
     def _handle_job_status(
             proxmox_api: ProxmoxApi,

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -12,12 +12,13 @@ __license__ = "GPL-3.0"
 
 import proxmoxer
 import time
-from itertools import islice
 from proxlb.utils.logger import SystemdLogger
 from proxlb.utils.proxmox_api import ProxmoxApi
 from proxlb.utils.config_parser import Config
 from proxlb.utils.proxlb_data import ProxLbData
-from typing import Dict, Generator, Optional, assert_never
+from pydantic import BaseModel
+from enum import Enum
+from typing import Optional, assert_never
 
 GuestType = Config.GuestType
 
@@ -32,135 +33,192 @@ class Balancing:
     values by an operator.
 
     Methods:
-    __init__(self, proxmox_api: any, proxlb_data: Dict[str, Any]):
-        Initializes the Balancing class with the provided ProxLB data and initiates the rebalancing
-        process for guests.
+    balance(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData) -> bool:
+        Runs the streaming migration queue: starts migrations up to the parallel job limit and
+        immediately fills each free slot as a job completes, rather than waiting for an entire
+        batch to finish. Returns True if all migrations completed successfully, False otherwise.
 
-    exec_rebalancing_vm(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
-        Executes the rebalancing of a virtual machine (VM) to a new node within the cluster. Logs the migration
-        process and handles exceptions.
+    _exec_rebalancing(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
+        Dispatches a single guest to the appropriate migration method based on its type.
+        Returns the Proxmox job ID on success, None otherwise.
 
-    exec_rebalancing_ct(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str) -> None:
-        Executes the rebalancing of a container (CT) to a new node within the cluster. Logs the migration
-        process and handles exceptions.
+    _exec_rebalancing_vm(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
+        Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
 
-    get_rebalancing_job_status(self, proxmox_api: any, proxlb_data: Dict[str, Any], guest_name: str, guest_current_node: str, job_id: int, retry_counter: int = 1) -> bool:
-        Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout
-        is reached. Returns True if the job completed successfully, False otherwise.
+    _exec_rebalancing_ct(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
+        Executes the rebalancing of a container (CT) to a new node within the cluster.
+
+    _handle_job_status(proxmox_api: ProxmoxApi, job: RebalancingJob, jobs_to_wait: list, max_retries: int) -> bool:
+        Checks a single in-flight job and removes it from jobs_to_wait when done.
+        Returns True if the job entered an error state.
+
+    _get_rebalancing_job_status(proxmox_api: ProxmoxApi, job: RebalancingJob) -> BalancingStatus:
+        Returns the current BalancingStatus of a migration job.
+
+    get_parallel_job_limit(proxlb_data_meta_balancing: ProxLbData.Meta.Balancing) -> int:
+        Returns the maximum number of parallel migration jobs from the balancing config.
     """
 
-    def __init__(self, proxmox_api: ProxmoxApi, proxlb_data: ProxLbData) -> None:
+    class BalancingStatus(Enum):
         """
-        Initializes the Balancing class with the provided ProxLB data.
+        Represents the current status of an in-flight rebalancing operation.
+        Used to update the streaming job queue after each status poll.
+        """
+        RUNNING = "running"
+        FINISHED = "finished"
+        FAILED = "failed"
+
+    class RebalancingJob(BaseModel):
+        """
+        Holds tracking information for a single in-flight migration job.
+        """
+        name: str
+        id: int
+        current_node: str
+        job_id: str
+        retry_counter: int = 0
+
+    @staticmethod
+    def balance(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData) -> bool:
+        """
+        Runs the streaming migration queue.
+
+        Keeps up to parallel_job_limit migrations in flight at once and immediately
+        submits the next guest as soon as a slot becomes free, rather than waiting
+        for an entire chunk to finish.
 
         Args:
-            proxmox_api (object): The Proxmox API client instance used to interact with the Proxmox cluster.
-            proxlb_data (dict): A dictionary containing data related to the ProxLB load balancing configuration.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            proxlb_data (ProxLbData): ProxLB load balancing data.
+
+        Returns:
+            bool: True if all migrations completed successfully, False otherwise.
         """
-        def chunk_dict(data: Dict[str, ProxLbData.Guest], size: int) -> Generator[Dict[str, ProxLbData.Guest], None, None]:
-            """
-            Splits a dictionary into chunks of a specified size.
-            Args:
-                data (dict): The dictionary to be split into chunks.
-                size (int): The size of each chunk.
-            Yields:
-                dict: A chunk of the original dictionary with the specified size.
-            """
-            logger.debug("Starting: chunk_dict.")
-            it = iter(data.items())
-            for chunk in range(0, len(data), size):
-                yield dict(islice(it, size))
+        logger.debug("Starting: balance.")
+        parallel_job_limit = Balancing.get_parallel_job_limit(proxlb_data.meta.balancing)
 
-        # Validate if balancing should be performed in parallel or sequentially.
-        # If parallel balancing is enabled, set the number of parallel jobs.
-        parallel_jobs = proxlb_data.meta.balancing.parallel_jobs
-        if not proxlb_data.meta.balancing.parallel:
-            parallel_jobs = 1
-            logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
-        else:
-            logger.debug(f"Balancing: Parallel balancing is enabled. Running with {parallel_jobs} parallel jobs.")
+        jobs_to_wait: list[Balancing.RebalancingJob] = []
+        max_retries = proxlb_data.meta.balancing.max_job_validation
+        item_iterator = iter(proxlb_data.guests.items())
+        migration_done = False
+        error_occurred = False
 
-        for chunk in chunk_dict(proxlb_data.guests, parallel_jobs):
-            jobs_to_wait = []
+        logger.debug("Starting: Balancing loop for guests.")
+        while True:
+            element = next(item_iterator, None)
+            if not element:
+                logger.debug("Finished: no more guests to process.")
+                migration_done = True
+            else:
+                guest_name, guest_meta = element
+                job_id = Balancing._exec_rebalancing(proxmox_api, proxlb_data, guest_name)
 
-            for guest_name, guest_meta in chunk.items():
+                if job_id is not None:
+                    jobs_to_wait.append(Balancing.RebalancingJob(
+                        name=guest_name,
+                        id=guest_meta.id,
+                        current_node=guest_meta.node_current,
+                        job_id=job_id,
+                    ))
 
-                # Check if the guest's target is not the same as the current node
-                if guest_meta.node_current != guest_meta.node_target:
+            # Wait for at least one job to complete when the queue is full or all guests are queued
+            while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
+                for job in list(jobs_to_wait):
+                    if Balancing._handle_job_status(proxmox_api, job, jobs_to_wait, max_retries):
+                        error_occurred = True
 
-                    # Check if the guest is not ignored and perform the balancing
-                    # operation based on the guest type
-                    if not guest_meta.ignore:
-                        job_id = None
+                if len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
+                    time.sleep(5)
 
-                        # VM Balancing
-                        if guest_meta.type == GuestType.Vm:
-                            if GuestType.Vm in proxlb_data.meta.balancing.balance_types:
-                                logger.debug(f"Balancing: Balancing for guest {guest_name} of type VM started.")
-                                job_id = self.exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
-                            else:
-                                logger.debug(
-                                    f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                    "Guest is of type VM which is not included in allowed balancing types.")
+            if migration_done and len(jobs_to_wait) == 0:
+                logger.debug("Finished: Balancing loop for guests. All guests processed and migrations processed.")
+                break
 
-                        # CT Balancing
-                        elif guest_meta.type == GuestType.Ct:
-                            if GuestType.Ct in proxlb_data.meta.balancing.balance_types:
-                                logger.debug(f"Balancing: Balancing for guest {guest_name} of type CT started.")
-                                job_id = self.exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
-                            else:
-                                logger.debug(
-                                    f"Balancing: Balancing for guest {guest_name} will not be performed. "
-                                    "Guest is of type CT which is not included in allowed balancing types.")
+        if error_occurred:
+            logger.warning(
+                "Balancing: Some migrations did not complete successfully. "
+                "Please check the logs and Proxmox cluster manually.")
+            logger.debug("Finished: balance.")
+            return False
 
-                        # Just in case we get a new type of guest in the future
-                        else:
-                            logger.critical(f"Balancing: Got unexpected guest type: {guest_meta.type}. Cannot proceed guest: {guest_meta.name}.")
-                            assert_never(guest_meta.type)
+        logger.info("Finished: Balancing loop for guests. All guests processed and migrations completed.")
+        return True
 
-                        if job_id:
-                            jobs_to_wait.append((guest_name, guest_meta.node_current, job_id))
+    @staticmethod
+    def _exec_rebalancing(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
+        """
+        Dispatches a single guest to the appropriate migration method based on its type.
 
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            proxlb_data (ProxLbData): ProxLB load balancing data.
+            guest_name (str): The name of the guest to be migrated.
+
+        Returns:
+            Optional[str]: The Proxmox job ID if a migration was started, None otherwise.
+        """
+        logger.debug("Starting: _exec_rebalancing.")
+        guest_meta = proxlb_data.guests[guest_name]
+        job_id = None
+
+        logger.debug(f"Balancing: Processing guest {guest_name} for potential rebalancing.")
+
+        if guest_meta.node_current != guest_meta.node_target:
+            if not guest_meta.ignore:
+                if guest_meta.type == GuestType.Vm:
+                    if GuestType.Vm in proxlb_data.meta.balancing.balance_types:
+                        logger.debug(f"Balancing: Balancing for guest {guest_name} of type VM started.")
+                        job_id = Balancing._exec_rebalancing_vm(proxmox_api, proxlb_data, guest_name)
                     else:
-                        logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
+                        logger.debug(
+                            f"Balancing: Balancing for guest {guest_name} will not be performed. "
+                            "Guest is of type VM which is not included in allowed balancing types.")
+
+                elif guest_meta.type == GuestType.Ct:
+                    if GuestType.Ct in proxlb_data.meta.balancing.balance_types:
+                        logger.debug(f"Balancing: Balancing for guest {guest_name} of type CT started.")
+                        job_id = Balancing._exec_rebalancing_ct(proxmox_api, proxlb_data, guest_name)
+                    else:
+                        logger.debug(
+                            f"Balancing: Balancing for guest {guest_name} will not be performed. "
+                            "Guest is of type CT which is not included in allowed balancing types.")
+
                 else:
-                    logger.debug(f"Balancing: Guest {guest_name} is already on the target node {guest_meta.node_target} and will not be rebalanced.")
+                    logger.critical(
+                        f"Balancing: Got unexpected guest type: {guest_meta.type}. "
+                        f"Cannot proceed guest: {guest_meta.name}.")
+                    assert_never(guest_meta.type)
+            else:
+                logger.debug(f"Balancing: Guest {guest_name} is ignored and will not be rebalanced.")
+        else:
+            logger.debug(
+                f"Balancing: Guest {guest_name} is already on the target node "
+                f"{guest_meta.node_target} and will not be rebalanced.")
 
-            # Wait for all jobs in the current chunk to complete
-            for guest_name, node, job_id in jobs_to_wait:
-                if job_id:
-                    self.get_rebalancing_job_status(proxmox_api, proxlb_data, guest_name, node, job_id)
+        logger.debug("Finished: _exec_rebalancing.")
+        return job_id
 
-    def exec_rebalancing_vm(self, proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
+    @staticmethod
+    def _exec_rebalancing_vm(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
-        This function initiates the migration of a specified VM to a target node as part of the
-        load balancing process. It logs the migration process and handles any exceptions that
-        may occur during the migration.
+
         Args:
-            proxmox_api (object): The Proxmox API client instance used to interact with the Proxmox cluster.
-            proxlb_data (dict): A dictionary containing data related to the ProxLB load balancing configuration.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            proxlb_data (ProxLbData): ProxLB load balancing data.
             guest_name (str): The name of the guest VM to be migrated.
-        Raises:
-            proxmox_api.core.ResourceException: If an error occurs during the migration process.
+
         Returns:
-            None
+            Optional[str]: The Proxmox job ID if the migration was started, None otherwise.
         """
-        logger.debug("Starting: exec_rebalancing_vm.")
+        logger.debug("Starting: _exec_rebalancing_vm.")
         guest_id = proxlb_data.guests[guest_name].id
         guest_node_current = proxlb_data.guests[guest_name].node_current
         guest_node_target = proxlb_data.guests[guest_name].node_target
         job_id = None
 
-        if proxlb_data.meta.balancing.live:
-            online_migration = 1
-        else:
-            online_migration = 0
-
-        if proxlb_data.meta.balancing.with_local_disks:
-            with_local_disks = 1
-        else:
-            with_local_disks = 0
+        online_migration = 1 if proxlb_data.meta.balancing.live else 0
+        with_local_disks = 1 if proxlb_data.meta.balancing.with_local_disks else 0
 
         migration_options = {
             'target': guest_node_target,
@@ -174,104 +232,177 @@ class Balancing:
             migration_options['with-conntrack-state'] = 1
 
         try:
-            logger.info(f"Balancing: Starting to migrate VM guest {guest_name} from {guest_node_current} to {guest_node_target}.")
+            logger.info(
+                f"Balancing: Starting to migrate VM guest {guest_name} "
+                f"from {guest_node_current} to {guest_node_target}.")
             job_id = proxmox_api.nodes(guest_node_current).qemu(guest_id).migrate().post(**migration_options)
         except proxmoxer.core.ResourceException as proxmox_api_error:
-            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors. Please check if resource is locked or similar.")
-            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors: {proxmox_api_error}")
+            logger.critical(
+                f"Balancing: Failed to migrate guest {guest_name} of type VM due to some Proxmox errors. "
+                "Please check if resource is locked or similar.")
+            logger.debug(
+                f"Balancing: Failed to migrate guest {guest_name} of type VM due to "
+                f"some Proxmox errors: {proxmox_api_error}")
 
-        logger.debug("Finished: exec_rebalancing_vm.")
+        logger.debug("Finished: _exec_rebalancing_vm.")
         return job_id
 
-    def exec_rebalancing_ct(self, proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
+    @staticmethod
+    def _exec_rebalancing_ct(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
         """
         Executes the rebalancing of a container (CT) to a new node within the cluster.
-        This function initiates the migration of a specified CT to a target node as part of the
-        load balancing process. It logs the migration process and handles any exceptions that
-        may occur during the migration.
+
         Args:
-            proxmox_api (object): The Proxmox API client instance used to interact with the Proxmox cluster.
-            proxlb_data (dict): A dictionary containing data related to the ProxLB load balancing configuration.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            proxlb_data (ProxLbData): ProxLB load balancing data.
             guest_name (str): The name of the guest CT to be migrated.
-        Raises:
-            proxmox_api.core.ResourceException: If an error occurs during the migration process.
+
         Returns:
-            None
+            Optional[str]: The Proxmox job ID if the migration was started, None otherwise.
         """
-        logger.debug("Starting: exec_rebalancing_ct.")
+        logger.debug("Starting: _exec_rebalancing_ct.")
         guest_id = proxlb_data.guests[guest_name].id
         guest_node_current = proxlb_data.guests[guest_name].node_current
         guest_node_target = proxlb_data.guests[guest_name].node_target
         job_id = None
 
         try:
-            logger.info(f"Balancing: Starting to migrate CT guest {guest_name} from {guest_node_current} to {guest_node_target}.")
-            job_id = proxmox_api.nodes(guest_node_current).lxc(guest_id).migrate().post(target=guest_node_target, restart=1)
+            logger.info(
+                f"Balancing: Starting to migrate CT guest {guest_name} "
+                f"from {guest_node_current} to {guest_node_target}.")
+            job_id = proxmox_api.nodes(guest_node_current).lxc(guest_id).migrate().post(
+                target=guest_node_target, restart=1)
         except proxmoxer.core.ResourceException as proxmox_api_error:
-            logger.critical(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. Please check if resource is locked or similar.")
-            logger.debug(f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors: {proxmox_api_error}")
+            logger.critical(
+                f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. "
+                "Please check if resource is locked or similar.")
+            logger.debug(
+                f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors: "
+                f"{proxmox_api_error}")
 
-        logger.debug("Finished: exec_rebalancing_ct.")
+        logger.debug("Finished: _exec_rebalancing_ct.")
         return job_id
 
-    def get_rebalancing_job_status(self, proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str, guest_current_node: str, job_id: str, retry_counter: int = 1) -> bool:
+    @staticmethod
+    def _handle_job_status(
+            proxmox_api: ProxmoxApi,
+            job: 'Balancing.RebalancingJob',
+            jobs_to_wait: 'list[Balancing.RebalancingJob]',
+            max_retries: int,
+    ) -> bool:
         """
-        Monitors the status of a rebalancing job on a Proxmox node until it completes or a timeout is reached.
+        Checks the current status of a single in-flight migration job and updates jobs_to_wait.
 
         Args:
-            proxmox_api (object): The Proxmox API client instance.
-            proxlb_data (dict): The ProxLB configuration data.
-            guest_name (str): The name of the guest (virtual machine) being rebalanced.
-            guest_current_node (str): The current node where the guest is running.
-            job_id (str): The ID of the rebalancing job to monitor.
-            retry_counter (int, optional): The current retry count. Defaults to 1.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            job (RebalancingJob): The job whose status to check.
+            jobs_to_wait (list): The list of currently in-flight jobs (mutated in place).
+            max_retries (int): Maximum number of status checks before the job is timed out.
 
         Returns:
-            bool: True if the job completed successfully, False otherwise.
+            bool: True if the job entered an error state (FAILED or timed out), False otherwise.
         """
-        logger.debug("Starting: get_rebalancing_job_status.")
-        job = proxmox_api.nodes(guest_current_node).tasks(job_id).status().get()
+        status = Balancing._get_rebalancing_job_status(proxmox_api, job)
+        if status == Balancing.BalancingStatus.FINISHED:
+            jobs_to_wait.remove(job)
+            return False
+        if status == Balancing.BalancingStatus.FAILED:
+            logger.critical(
+                f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
+                "for migration went into an error! Please check manually.")
+            jobs_to_wait.remove(job)
+            return True
+        # RUNNING
+        job.retry_counter += 1
+        if job.retry_counter >= max_retries:
+            logger.warning(
+                f"Balancing: Job ID {job.job_id} (guest: {job.name}) for migration "
+                f"is still running. Retry counter: {job.retry_counter} exceeded.")
+            jobs_to_wait.remove(job)
+            return True
+        return False
+
+    @staticmethod
+    def _get_rebalancing_job_status(
+            proxmox_api: ProxmoxApi,
+            job: 'Balancing.RebalancingJob',
+    ) -> 'Balancing.BalancingStatus':
+        """
+        Returns the current BalancingStatus of a migration job by polling the Proxmox API.
+
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            job (RebalancingJob): The job to poll.
+
+        Returns:
+            BalancingStatus: RUNNING, FINISHED, or FAILED.
+        """
+        logger.debug("Starting: _get_rebalancing_job_status.")
+        task = proxmox_api.nodes(job.current_node).tasks(job.job_id).status().get()
+        job_id = job.job_id
 
         # Fetch actual migration job status if this got spawned by a HA job
-        if job["type"] == "hamigrate":
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) is a HA migration job. Fetching underlying migration job...")
+        if task["type"] == "hamigrate":
+            logger.debug(
+                f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
+                "is a HA migration job. Fetching underlying migration job...")
             time.sleep(1)
-            vm_id = int(job["id"])
-            qm_migrate_jobs = proxmox_api.nodes(guest_current_node).tasks.get(typefilter="qmigrate", vmid=vm_id, start=0, source="active", limit=1)
+            vm_id = job.id
+            qm_migrate_jobs = proxmox_api.nodes(job.current_node).tasks.get(
+                typefilter="qmigrate", vmid=vm_id, start=0, source="active", limit=1)
 
             if len(qm_migrate_jobs) > 0:
-                job = qm_migrate_jobs[0]
-                job_id = job["upid"]
-                logger.debug(f'Overwriting job polling for: ID {job_id} (guest: {guest_name}) by {job}')
+                task = qm_migrate_jobs[0]
+                job_id = task["upid"]
+                logger.debug(f"Overwriting job polling for: ID {job_id} (guest: {job.name}) by {task}")
         else:
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) is a standard migration job. Proceeding with status check.")
+            logger.debug(
+                f"Balancing: Job ID {job_id} (guest: {job.name}) is a standard migration job. "
+                "Proceeding with status check.")
 
-        # Watch job id until it finalizes
-        # Note: Unsaved jobs are delivered in uppercase from Proxmox API
-        if job.get("status", "").lower() == "running":
-            # Do not hammer the API while
-            # watching the job status
-            time.sleep(10)
-            retry_counter += 1
+        # Note: unsaved jobs are delivered in uppercase from the Proxmox API
+        task_status = task.get("status", "").lower()
+        if task_status == "running":
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) for migration is still running...")
+            return Balancing.BalancingStatus.RUNNING
 
-            # Run recursion until we hit the soft-limit of maximum migration time for a guest
-            if retry_counter < proxlb_data.meta.balancing.max_job_validation:
-                logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) for migration is still running... (Run: {retry_counter})")
-                self.get_rebalancing_job_status(proxmox_api, proxlb_data, guest_name, guest_current_node, job_id, retry_counter)
+        if task_status == "stopped":
+            if task.get("exitstatus", "") == "OK":
+                logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) was successfully.")
+                logger.debug("Finished: _get_rebalancing_job_status.")
+                return Balancing.BalancingStatus.FINISHED
             else:
-                logger.warning(f"Balancing: Job ID {job_id} (guest: {guest_name}) for migration took too long. Please check manually.")
-                logger.debug("Finished: get_rebalancing_job_status.")
-                return False
+                logger.critical(
+                    f"Balancing: Job ID {job_id} (guest: {job.name}) went into an error! "
+                    "Please check manually.")
+                logger.debug("Finished: _get_rebalancing_job_status.")
+                return Balancing.BalancingStatus.FAILED
 
-        # Validate job output for errors when finished
-        if job["status"] == "stopped":
+        raise AssertionError(
+            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job.name}): "
+            f"{task.get('status', '')}. Please check manually.")
 
-            if job["exitstatus"] == "OK":
-                logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) was successfully.")
-                logger.debug("Finished: get_rebalancing_job_status.")
-                return True
-            else:
-                logger.critical(f"Balancing: Job ID {job_id} (guest: {guest_name}) went into an error! Please check manually.")
-                logger.debug("Finished: get_rebalancing_job_status.")
-                return False
-        return False
+    @staticmethod
+    def get_parallel_job_limit(proxlb_data_meta_balancing: ProxLbData.Meta.Balancing) -> int:
+        """
+        Returns the maximum number of parallel migration jobs from the balancing config.
+
+        Args:
+            proxlb_data_meta_balancing (ProxLbData.Meta.Balancing): The balancing sub-config.
+
+        Returns:
+            int: The parallel job limit (always >= 1).
+        """
+        if not proxlb_data_meta_balancing.parallel:
+            logger.debug("Balancing: Parallel balancing is disabled. Running sequentially.")
+            return 1
+
+        limit = proxlb_data_meta_balancing.parallel_jobs
+        if limit < 1:
+            logger.warning(
+                "Balancing: Invalid parallel_jobs value. Parallel job limit must be at least 1. "
+                "Defaulting to 1.")
+            return 1
+
+        logger.debug(f"Balancing: Parallel balancing is enabled. Running with {limit} parallel jobs.")
+        return limit

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -99,41 +99,31 @@ class Balancing:
 
         jobs_to_wait: list[Balancing.RebalancingJob] = []
         max_retries = proxlb_data.meta.balancing.max_job_validation
-        item_iterator = iter(proxlb_data.guests.items())
-        migration_done = False
         error_occurred = False
 
         logger.debug("Starting: Balancing loop for guests.")
-        while True:
-            element = next(item_iterator, None)
-            if not element:
-                logger.debug("Finished: no more guests to process.")
-                migration_done = True
-            else:
-                guest_name, guest_meta = element
-                job_id = Balancing._exec_rebalancing(proxmox_api, proxlb_data, guest_name)
-
-                if job_id is not None:
-                    jobs_to_wait.append(Balancing.RebalancingJob(
-                        name=guest_name,
-                        id=guest_meta.id,
-                        current_node=guest_meta.node_current,
-                        job_id=job_id,
-                    ))
-
-            # Wait for at least one job to complete when the queue is full or all guests are queued
-            while len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
-                for job in list(jobs_to_wait):
-                    if Balancing._handle_job_status(proxmox_api, job, jobs_to_wait, max_retries):
-                        error_occurred = True
-
-                if len(jobs_to_wait) >= parallel_job_limit or (migration_done and len(jobs_to_wait) > 0):
+        for guest_name, guest_meta in proxlb_data.guests.items():
+            while len(jobs_to_wait) >= parallel_job_limit:
+                if Balancing._check_jobs_and_update(proxmox_api, jobs_to_wait, max_retries):
+                    error_occurred = True
+                if len(jobs_to_wait) >= parallel_job_limit:
                     time.sleep(5)
 
-            if migration_done and len(jobs_to_wait) == 0:
-                logger.debug("Finished: Balancing loop for guests. All guests processed and migrations processed.")
-                break
+            job_id = Balancing._exec_rebalancing(proxmox_api, proxlb_data, guest_name)
+            if job_id is not None:
+                jobs_to_wait.append(Balancing.RebalancingJob(
+                    name=guest_name,
+                    id=guest_meta.id,
+                    current_node=guest_meta.node_current,
+                    job_id=job_id,
+                ))
 
+        while jobs_to_wait:
+            if Balancing._check_jobs_and_update(proxmox_api, jobs_to_wait, max_retries):
+              error_occurred = True
+            if jobs_to_wait:
+              time.sleep(5)
+        
         if error_occurred:
             logger.warning(
                 "Balancing: Some migrations did not complete successfully. "
@@ -283,6 +273,25 @@ class Balancing:
         logger.debug("Finished: _exec_rebalancing_ct.")
         return job_id
 
+    @staticmethod
+    def _check_jobs_and_update(proxmox_api: ProxmoxApi, jobs_to_wait: list['Balancing.RebalancingJob'], max_retries: int) -> bool:
+        """
+        Checks the status of all in-flight jobs and updates the jobs_to_wait list accordingly.
+
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            jobs_to_wait (list): The list of currently in-flight jobs (mutated in place).
+            max_retries (int): Maximum number of status checks before the job is timed out.
+
+        Returns:
+            bool: True if any job entered an error state (FAILED or timed out), False otherwise.
+        """
+        error_occurred = False
+        for job in list(jobs_to_wait):
+            if Balancing._handle_job_status(proxmox_api, job, jobs_to_wait, max_retries):
+                error_occurred = True
+        return error_occurred
+    
     @staticmethod
     def _handle_job_status(
             proxmox_api: ProxmoxApi,

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -287,7 +287,7 @@ class Balancing:
     def _handle_job_status(
             proxmox_api: ProxmoxApi,
             job: 'Balancing.RebalancingJob',
-            jobs_to_wait: 'list[Balancing.RebalancingJob]',
+            jobs_to_wait: list['Balancing.RebalancingJob'],
             max_retries: int,
     ) -> bool:
         """

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -96,6 +96,7 @@ class Balancing:
         """
         logger.debug("Starting: balance.")
         parallel_job_limit = Balancing.get_parallel_job_limit(proxlb_data.meta.balancing)
+        logger.debug(f"Balancing: parallel_job_limit resolved to {parallel_job_limit}.")
 
         jobs_to_wait: list[Balancing.RebalancingJob] = []
         max_retries = proxlb_data.meta.balancing.max_job_validation
@@ -110,6 +111,7 @@ class Balancing:
                     time.sleep(5)
 
             job_id = Balancing._exec_rebalancing(proxmox_api, proxlb_data, guest_name)
+            logger.debug(f"Balancing: job_id for {guest_name}: {job_id!r}, jobs_to_wait len: {len(jobs_to_wait)}")
             if job_id is not None:
                 jobs_to_wait.append(Balancing.RebalancingJob(
                     name=guest_name,

--- a/proxlb/models/tests/test_balancing_exec_rebalancing.py
+++ b/proxlb/models/tests/test_balancing_exec_rebalancing.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for Balancing._exec_rebalancing().
+
+These tests cover the routing and filtering logic inside _exec_rebalancing():
+which guest types trigger a migration, which are silently skipped, and how
+unknown types are handled. The streaming queue machinery in balance() is
+tested separately in test_balancing_streaming_queue.py.
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from proxlb.models.balancing import Balancing
+from proxlb.utils.config_parser import Config
+
+GuestType = Config.GuestType
+
+
+def _guest(
+        guest_id: int,
+        node_current: str,
+        node_target: str,
+        guest_type: GuestType = GuestType.Vm,
+        ignore: bool = False,
+) -> MagicMock:
+    g = MagicMock()
+    g.id = guest_id
+    g.type = guest_type
+    g.node_current = node_current
+    g.node_target = node_target
+    g.ignore = ignore
+    g.name = f"guest-{guest_id}"
+    return g
+
+
+def _vm(node_current: str = "node1", node_target: str = "node2", ignore: bool = False) -> MagicMock:
+    return _guest(101, node_current, node_target, GuestType.Vm, ignore)
+
+
+def _ct(node_current: str = "node1", node_target: str = "node2", ignore: bool = False) -> MagicMock:
+    return _guest(201, node_current, node_target, GuestType.Ct, ignore)
+
+
+def _proxlb_data(
+        guest_name: str,
+        guest: MagicMock,
+        balance_types: list[GuestType] | None = None,
+) -> MagicMock:
+    if balance_types is None:
+        balance_types = [GuestType.Vm, GuestType.Ct]
+    data = MagicMock()
+    data.meta.balancing.balance_types = balance_types
+    data.meta.balancing.live = True
+    data.meta.balancing.with_local_disks = True
+    data.meta.balancing.with_conntrack_state = True
+    data.guests = {guest_name: guest}
+    return data
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_vm_in_balance_types_delegates_to_exec_rebalancing_vm(mock_ct, mock_vm) -> None:
+    """A VM guest whose type is listed in balance_types must trigger _exec_rebalancing_vm."""
+    mock_vm.return_value = "UPID:node1:vm1"
+    proxlb_data = _proxlb_data("vm1", _vm(), balance_types=[GuestType.Vm])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "vm1")
+
+    mock_vm.assert_called_once()
+    mock_ct.assert_not_called()
+    assert job_id == "UPID:node1:vm1"
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_vm_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
+    """A VM guest whose type is not listed in balance_types must be skipped (returns None)."""
+    proxlb_data = _proxlb_data("vm1", _vm(), balance_types=[GuestType.Ct])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "vm1")
+
+    mock_vm.assert_not_called()
+    mock_ct.assert_not_called()
+    assert job_id is None
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_ct_in_balance_types_delegates_to_exec_rebalancing_ct(mock_ct, mock_vm) -> None:
+    """A CT guest whose type is listed in balance_types must trigger _exec_rebalancing_ct."""
+    mock_ct.return_value = "UPID:node1:ct1"
+    proxlb_data = _proxlb_data("ct1", _ct(), balance_types=[GuestType.Ct])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "ct1")
+
+    mock_ct.assert_called_once()
+    mock_vm.assert_not_called()
+    assert job_id == "UPID:node1:ct1"
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_ct_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
+    """A CT guest whose type is not listed in balance_types must be skipped (returns None)."""
+    proxlb_data = _proxlb_data("ct1", _ct(), balance_types=[GuestType.Vm])
+
+    job_id = Balancing._exec_rebalancing(MagicMock(), proxlb_data, "ct1")
+
+    mock_ct.assert_not_called()
+    mock_vm.assert_not_called()
+    assert job_id is None
+
+
+@patch.object(Balancing, "_exec_rebalancing_vm")
+@patch.object(Balancing, "_exec_rebalancing_ct")
+def test_unknown_guest_type_raises(mock_ct, mock_vm) -> None:
+    """An unknown guest type must raise AssertionError via assert_never (all valid types exhausted)."""
+    odd_guest = MagicMock()
+    odd_guest.id = 301
+    odd_guest.type = "unknown"  # not a GuestType member — triggers assert_never
+    odd_guest.node_current = "node1"
+    odd_guest.node_target = "node2"
+    odd_guest.ignore = False
+    odd_guest.name = "odd1"
+    proxlb_data = _proxlb_data("odd1", odd_guest, balance_types=[GuestType.Vm, GuestType.Ct])
+
+    with pytest.raises((AssertionError, TypeError)):
+        Balancing._exec_rebalancing(MagicMock(), proxlb_data, "odd1")
+
+    mock_vm.assert_not_called()
+    mock_ct.assert_not_called()

--- a/proxlb/models/tests/test_balancing_exec_rebalancing.py
+++ b/proxlb/models/tests/test_balancing_exec_rebalancing.py
@@ -64,7 +64,7 @@ def _proxlb_data(
 
 @patch.object(Balancing, "_exec_rebalancing_vm")
 @patch.object(Balancing, "_exec_rebalancing_ct")
-def test_vm_in_balance_types_delegates_to_exec_rebalancing_vm(mock_ct, mock_vm) -> None:
+def test_vm_in_balance_types_delegates_to_exec_rebalancing_vm(mock_ct: MagicMock, mock_vm: MagicMock) -> None:
     """A VM guest whose type is listed in balance_types must trigger _exec_rebalancing_vm."""
     mock_vm.return_value = "UPID:node1:vm1"
     proxlb_data = _proxlb_data("vm1", _vm(), balance_types=[GuestType.Vm])
@@ -78,7 +78,7 @@ def test_vm_in_balance_types_delegates_to_exec_rebalancing_vm(mock_ct, mock_vm) 
 
 @patch.object(Balancing, "_exec_rebalancing_vm")
 @patch.object(Balancing, "_exec_rebalancing_ct")
-def test_vm_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
+def test_vm_not_in_balance_types_returns_none(mock_ct: MagicMock, mock_vm: MagicMock) -> None:
     """A VM guest whose type is not listed in balance_types must be skipped (returns None)."""
     proxlb_data = _proxlb_data("vm1", _vm(), balance_types=[GuestType.Ct])
 
@@ -91,7 +91,7 @@ def test_vm_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
 
 @patch.object(Balancing, "_exec_rebalancing_vm")
 @patch.object(Balancing, "_exec_rebalancing_ct")
-def test_ct_in_balance_types_delegates_to_exec_rebalancing_ct(mock_ct, mock_vm) -> None:
+def test_ct_in_balance_types_delegates_to_exec_rebalancing_ct(mock_ct: MagicMock, mock_vm: MagicMock) -> None:
     """A CT guest whose type is listed in balance_types must trigger _exec_rebalancing_ct."""
     mock_ct.return_value = "UPID:node1:ct1"
     proxlb_data = _proxlb_data("ct1", _ct(), balance_types=[GuestType.Ct])
@@ -105,7 +105,7 @@ def test_ct_in_balance_types_delegates_to_exec_rebalancing_ct(mock_ct, mock_vm) 
 
 @patch.object(Balancing, "_exec_rebalancing_vm")
 @patch.object(Balancing, "_exec_rebalancing_ct")
-def test_ct_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
+def test_ct_not_in_balance_types_returns_none(mock_ct: MagicMock, mock_vm: MagicMock) -> None:
     """A CT guest whose type is not listed in balance_types must be skipped (returns None)."""
     proxlb_data = _proxlb_data("ct1", _ct(), balance_types=[GuestType.Vm])
 
@@ -118,7 +118,7 @@ def test_ct_not_in_balance_types_returns_none(mock_ct, mock_vm) -> None:
 
 @patch.object(Balancing, "_exec_rebalancing_vm")
 @patch.object(Balancing, "_exec_rebalancing_ct")
-def test_unknown_guest_type_raises(mock_ct, mock_vm) -> None:
+def test_unknown_guest_type_raises(mock_ct: MagicMock, mock_vm: MagicMock) -> None:
     """An unknown guest type must raise AssertionError via assert_never (all valid types exhausted)."""
     odd_guest = MagicMock()
     odd_guest.id = 301

--- a/proxlb/models/tests/test_balancing_get_parallel_job_limit.py
+++ b/proxlb/models/tests/test_balancing_get_parallel_job_limit.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for Balancing.get_parallel_job_limit().
+
+These tests verify that the static method correctly parses the balancing
+configuration and clamps invalid values, in particular the edge case where
+parallel mode is enabled but parallel_jobs is set to a value below 1 (which
+would otherwise cause an infinite loop in the streaming queue).
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+from proxlb.models.balancing import Balancing
+from proxlb.utils.proxlb_data import ProxLbData
+
+
+def test_returns_1_when_parallel_is_disabled_by_default() -> None:
+    """Missing parallel key must default to sequential mode (limit=1)."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing()) == 1
+
+
+def test_returns_1_when_parallel_is_false() -> None:
+    """Explicitly disabled parallel mode must return limit=1."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing(parallel=False)) == 1
+
+
+def test_returns_default_5_when_parallel_jobs_not_overridden() -> None:
+    """parallel=True without overriding parallel_jobs must return the built-in default of 5."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing(parallel=True)) == 5
+
+
+def test_returns_configured_value_when_parallel_jobs_is_valid() -> None:
+    """A valid parallel_jobs value must be returned unchanged."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing(parallel=True, parallel_jobs=3)) == 3
+
+
+def test_returns_1_when_parallel_jobs_is_exactly_1() -> None:
+    """parallel_jobs=1 is the minimum valid value and must be accepted as-is."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing(parallel=True, parallel_jobs=1)) == 1
+
+
+def test_clamps_to_1_when_parallel_jobs_is_zero() -> None:
+    """parallel_jobs=0 is invalid; the method must clamp it to 1 to prevent an infinite loop."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing(parallel=True, parallel_jobs=0)) == 1
+
+
+def test_clamps_to_1_when_parallel_jobs_is_negative() -> None:
+    """Negative parallel_jobs is invalid; the method must clamp it to 1."""
+    assert Balancing.get_parallel_job_limit(ProxLbData.Meta.Balancing(parallel=True, parallel_jobs=-5)) == 1

--- a/proxlb/models/tests/test_balancing_streaming_queue.py
+++ b/proxlb/models/tests/test_balancing_streaming_queue.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for the streaming migration queue in Balancing.balance().
+
+These tests verify that balance() correctly implements a continuous streaming
+queue: it keeps up to parallel_job_limit migrations in flight and immediately
+submits the next guest when a slot becomes free, rather than waiting for the
+entire current batch to finish.
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+from unittest.mock import MagicMock, patch
+
+from proxlb.models.balancing import Balancing
+from proxlb.utils.config_parser import Config
+
+GuestType = Config.GuestType
+
+FINISHED = Balancing.BalancingStatus.FINISHED
+RUNNING = Balancing.BalancingStatus.RUNNING
+FAILED = Balancing.BalancingStatus.FAILED
+
+
+def _guest(
+        guest_id: int,
+        node_current: str,
+        node_target: str,
+        ignore: bool = False,
+) -> MagicMock:
+    g = MagicMock()
+    g.id = guest_id
+    g.type = GuestType.Vm
+    g.node_current = node_current
+    g.node_target = node_target
+    g.ignore = ignore
+    g.name = f"vm{guest_id}"
+    return g
+
+
+def _proxlb_data(
+        guests: dict,
+        parallel: bool = True,
+        parallel_jobs: int = 2,
+) -> MagicMock:
+    data = MagicMock()
+    data.meta.balancing.parallel = parallel
+    data.meta.balancing.parallel_jobs = parallel_jobs
+    data.meta.balancing.max_job_validation = 1800
+    data.meta.balancing.balance_types = [GuestType.Vm]
+    data.meta.balancing.live = True
+    data.meta.balancing.with_local_disks = True
+    data.meta.balancing.with_conntrack_state = True
+    data.guests = guests
+    return data
+
+
+@patch("proxlb.models.balancing.time.sleep")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
+def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """Guests already on the target node must not trigger any migration."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node1"),
+        "vm2": _guest(102, "node2", "node2"),
+    })
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    mock_exec_vm.assert_not_called()
+    mock_get_status.assert_not_called()
+
+
+@patch("proxlb.models.balancing.time.sleep")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
+def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """Ignored guests must not be migrated even when their target node differs."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2", ignore=True),
+        "vm2": _guest(102, "node1", "node2", ignore=True),
+    })
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    mock_exec_vm.assert_not_called()
+
+
+@patch("proxlb.models.balancing.time.sleep")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
+def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """With parallel=False only one migration must be in flight at any point in time."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2"),
+        "vm2": _guest(102, "node1", "node2"),
+        "vm3": _guest(103, "node1", "node2"),
+    }, parallel=False)
+
+    in_flight = [0]
+    max_concurrent = [0]
+
+    def tracking_exec(api, data, name) -> str:
+        in_flight[0] += 1
+        max_concurrent[0] = max(max_concurrent[0], in_flight[0])
+        return f"job-{name}"
+
+    def tracking_status(api, job) -> Balancing.BalancingStatus:
+        in_flight[0] -= 1
+        return Balancing.BalancingStatus.FINISHED
+
+    mock_exec_vm.side_effect = tracking_exec
+    mock_get_status.side_effect = tracking_status
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    assert mock_exec_vm.call_count == 3
+    assert max_concurrent[0] == 1, f"Expected at most 1 concurrent migration, got {max_concurrent[0]}"
+
+
+@patch("proxlb.models.balancing.time.sleep")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
+def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """
+    Core streaming guarantee: with parallel_job_limit=2 and 3 guests, the 3rd
+    migration must be submitted as soon as the 1st finishes — without waiting
+    for the 2nd to finish too.
+
+    Expected call_log order:
+        submit vm1 → submit vm2 → finish vm1 → submit vm3 → finish vm2 → finish vm3
+    """
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2"),
+        "vm2": _guest(102, "node1", "node2"),
+        "vm3": _guest(103, "node1", "node2"),
+    }, parallel=True, parallel_jobs=2)
+
+    call_log: list[tuple[str, str]] = []
+
+    def tracking_exec(api, data, name) -> str:
+        call_log.append(("submit", name))
+        return f"job-{name}"
+
+    # vm1 finishes on its first status check; vm2 needs one RUNNING round before finishing
+    status_sequences = {
+        "job-vm1": iter([Balancing.BalancingStatus.FINISHED]),
+        "job-vm2": iter([Balancing.BalancingStatus.RUNNING, Balancing.BalancingStatus.FINISHED]),
+        "job-vm3": iter([Balancing.BalancingStatus.FINISHED]),
+    }
+
+    def tracking_status(api, job) -> Balancing.BalancingStatus:
+        result = next(status_sequences[job.job_id])
+        if result == Balancing.BalancingStatus.FINISHED:
+            call_log.append(("finish", job.name))
+        return result
+
+    mock_exec_vm.side_effect = tracking_exec
+    mock_get_status.side_effect = tracking_status
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    assert mock_exec_vm.call_count == 3
+
+    idx_submit_vm3 = call_log.index(("submit", "vm3"))
+    idx_finish_vm1 = call_log.index(("finish", "vm1"))
+    idx_finish_vm2 = call_log.index(("finish", "vm2"))
+
+    assert idx_finish_vm1 < idx_submit_vm3, (
+        "vm3 must be submitted after vm1 finishes (slot freed), "
+        f"but call_log was: {call_log}"
+    )
+    assert idx_submit_vm3 < idx_finish_vm2, (
+        "vm3 must be submitted before vm2 finishes (streaming, not batching), "
+        f"but call_log was: {call_log}"
+    )
+
+
+@patch("proxlb.models.balancing.time.sleep")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
+def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """The number of in-flight migrations must never exceed parallel_job_limit."""
+    limit = 3
+    num_guests = 9
+    proxlb_data = _proxlb_data(
+        {f"vm{i}": _guest(100 + i, "node1", "node2") for i in range(num_guests)},
+        parallel=True,
+        parallel_jobs=limit,
+    )
+
+    in_flight = [0]
+    max_concurrent = [0]
+
+    def tracking_exec(api, data, name) -> str:
+        in_flight[0] += 1
+        max_concurrent[0] = max(max_concurrent[0], in_flight[0])
+        return f"job-{name}"
+
+    def tracking_status(api, job) -> Balancing.BalancingStatus:
+        in_flight[0] -= 1
+        return Balancing.BalancingStatus.FINISHED
+
+    mock_exec_vm.side_effect = tracking_exec
+    mock_get_status.side_effect = tracking_status
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is True
+    assert mock_exec_vm.call_count == num_guests
+    assert max_concurrent[0] <= limit, (
+        f"Concurrency limit violated: {max_concurrent[0]} migrations were in flight, limit is {limit}"
+    )
+
+
+@patch("proxlb.models.balancing.time.sleep")
+@patch.object(Balancing, "_get_rebalancing_job_status")
+@patch.object(Balancing, "_exec_rebalancing_vm")
+def test_failed_migration_returns_false(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+    """A FAILED migration status must cause balance() to return False."""
+    proxlb_data = _proxlb_data({
+        "vm1": _guest(101, "node1", "node2"),
+    })
+
+    mock_exec_vm.return_value = "job-vm1"
+    mock_get_status.return_value = Balancing.BalancingStatus.FAILED
+
+    result = Balancing.balance(MagicMock(), proxlb_data)
+
+    assert result is False

--- a/proxlb/models/tests/test_balancing_streaming_queue.py
+++ b/proxlb/models/tests/test_balancing_streaming_queue.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from proxlb.models.balancing import Balancing
 from proxlb.utils.config_parser import Config
+from proxlb.utils.proxmox_api import ProxmoxApi
 
 GuestType = Config.GuestType
 
@@ -41,7 +42,7 @@ def _guest(
 
 
 def _proxlb_data(
-        guests: dict,
+        guests: dict[str, MagicMock],
         parallel: bool = True,
         parallel_jobs: int = 2,
 ) -> MagicMock:
@@ -60,7 +61,9 @@ def _proxlb_data(
 @patch("proxlb.models.balancing.time.sleep")
 @patch.object(Balancing, "_get_rebalancing_job_status")
 @patch.object(Balancing, "_exec_rebalancing_vm")
-def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+def test_no_migration_when_guests_already_on_target(
+        mock_exec_vm: MagicMock, mock_get_status: MagicMock, mock_sleep: MagicMock,
+) -> None:
     """Guests already on the target node must not trigger any migration."""
     proxlb_data = _proxlb_data({
         "vm1": _guest(101, "node1", "node1"),
@@ -77,7 +80,9 @@ def test_no_migration_when_guests_already_on_target(mock_exec_vm, mock_get_statu
 @patch("proxlb.models.balancing.time.sleep")
 @patch.object(Balancing, "_get_rebalancing_job_status")
 @patch.object(Balancing, "_exec_rebalancing_vm")
-def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+def test_no_migration_when_guests_are_ignored(
+        mock_exec_vm: MagicMock, mock_get_status: MagicMock, mock_sleep: MagicMock,
+) -> None:
     """Ignored guests must not be migrated even when their target node differs."""
     proxlb_data = _proxlb_data({
         "vm1": _guest(101, "node1", "node2", ignore=True),
@@ -93,7 +98,9 @@ def test_no_migration_when_guests_are_ignored(mock_exec_vm, mock_get_status, moc
 @patch("proxlb.models.balancing.time.sleep")
 @patch.object(Balancing, "_get_rebalancing_job_status")
 @patch.object(Balancing, "_exec_rebalancing_vm")
-def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+def test_sequential_mode_runs_one_migration_at_a_time(
+        mock_exec_vm: MagicMock, mock_get_status: MagicMock, mock_sleep: MagicMock,
+) -> None:
     """With parallel=False only one migration must be in flight at any point in time."""
     proxlb_data = _proxlb_data({
         "vm1": _guest(101, "node1", "node2"),
@@ -104,12 +111,12 @@ def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_sta
     in_flight = [0]
     max_concurrent = [0]
 
-    def tracking_exec(api, data, name) -> str:
+    def tracking_exec(api: ProxmoxApi, data: MagicMock, name: str) -> str:
         in_flight[0] += 1
         max_concurrent[0] = max(max_concurrent[0], in_flight[0])
         return f"job-{name}"
 
-    def tracking_status(api, job) -> Balancing.BalancingStatus:
+    def tracking_status(api: ProxmoxApi, job: Balancing.RebalancingJob) -> Balancing.BalancingStatus:
         in_flight[0] -= 1
         return Balancing.BalancingStatus.FINISHED
 
@@ -126,7 +133,9 @@ def test_sequential_mode_runs_one_migration_at_a_time(mock_exec_vm, mock_get_sta
 @patch("proxlb.models.balancing.time.sleep")
 @patch.object(Balancing, "_get_rebalancing_job_status")
 @patch.object(Balancing, "_exec_rebalancing_vm")
-def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+def test_parallel_streaming_submits_next_as_soon_as_slot_frees(
+        mock_exec_vm: MagicMock, mock_get_status: MagicMock, mock_sleep: MagicMock,
+) -> None:
     """
     Core streaming guarantee: with parallel_job_limit=2 and 3 guests, the 3rd
     migration must be submitted as soon as the 1st finishes — without waiting
@@ -143,7 +152,7 @@ def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, moc
 
     call_log: list[tuple[str, str]] = []
 
-    def tracking_exec(api, data, name) -> str:
+    def tracking_exec(api: ProxmoxApi, data: MagicMock, name: str) -> str:
         call_log.append(("submit", name))
         return f"job-{name}"
 
@@ -154,7 +163,7 @@ def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, moc
         "job-vm3": iter([Balancing.BalancingStatus.FINISHED]),
     }
 
-    def tracking_status(api, job) -> Balancing.BalancingStatus:
+    def tracking_status(api: ProxmoxApi, job: Balancing.RebalancingJob) -> Balancing.BalancingStatus:
         result = next(status_sequences[job.job_id])
         if result == Balancing.BalancingStatus.FINISHED:
             call_log.append(("finish", job.name))
@@ -185,7 +194,9 @@ def test_parallel_streaming_submits_next_as_soon_as_slot_frees(mock_exec_vm, moc
 @patch("proxlb.models.balancing.time.sleep")
 @patch.object(Balancing, "_get_rebalancing_job_status")
 @patch.object(Balancing, "_exec_rebalancing_vm")
-def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+def test_parallel_concurrency_never_exceeds_limit(
+        mock_exec_vm: MagicMock, mock_get_status: MagicMock, mock_sleep: MagicMock,
+) -> None:
     """The number of in-flight migrations must never exceed parallel_job_limit."""
     limit = 3
     num_guests = 9
@@ -198,12 +209,12 @@ def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status,
     in_flight = [0]
     max_concurrent = [0]
 
-    def tracking_exec(api, data, name) -> str:
+    def tracking_exec(api: ProxmoxApi, data: MagicMock, name: str) -> str:
         in_flight[0] += 1
         max_concurrent[0] = max(max_concurrent[0], in_flight[0])
         return f"job-{name}"
 
-    def tracking_status(api, job) -> Balancing.BalancingStatus:
+    def tracking_status(api: ProxmoxApi, job: Balancing.RebalancingJob) -> Balancing.BalancingStatus:
         in_flight[0] -= 1
         return Balancing.BalancingStatus.FINISHED
 
@@ -222,7 +233,9 @@ def test_parallel_concurrency_never_exceeds_limit(mock_exec_vm, mock_get_status,
 @patch("proxlb.models.balancing.time.sleep")
 @patch.object(Balancing, "_get_rebalancing_job_status")
 @patch.object(Balancing, "_exec_rebalancing_vm")
-def test_failed_migration_returns_false(mock_exec_vm, mock_get_status, mock_sleep) -> None:
+def test_failed_migration_returns_false(
+        mock_exec_vm: MagicMock, mock_get_status: MagicMock, mock_sleep: MagicMock,
+) -> None:
     """A FAILED migration status must cause balance() to return False."""
     proxlb_data = _proxlb_data({
         "vm1": _guest(101, "node1", "node2"),

--- a/proxlb/utils/config_parser.py
+++ b/proxlb/utils/config_parser.py
@@ -101,6 +101,7 @@ class Config(BaseModel):
         mode: Mode = Mode.Used
         node_resource_reserve: Optional[dict[str, dict["Config.Balancing.Resource", int]]] = None
         parallel: bool = False
+        parallel_jobs: int = 5
         pools: Optional[dict[str, Pool]] = None
         psi: Optional[Psi] = None
         with_conntrack_state: bool = True


### PR DESCRIPTION
This replaces https://github.com/credativ/ProxLB/pull/83 and should close #6 

Refactor Balancing class and implement streaming migration queue, added some unit tests. Please test intensively as I dont have too much test environment here around.

I skipped the linting stuff this time as I still don't see anything in the repository. 