### PR TITLE
Retry _get_rebalancing_job_status on ConnectionError

### DIFF
--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -315,6 +315,7 @@ class Balancing:
             bool: True if the job entered an error state (FAILED or timed out), False otherwise.
         """
         try:
+            time.sleep(0.1)
             status = Balancing._get_rebalancing_job_status(proxmox_api, job)
         except ConnectionError as exc:
             logger.warning(str(exc))

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -19,6 +19,7 @@ from proxlb.utils.proxlb_data import ProxLbData
 from pydantic import BaseModel
 from enum import Enum
 from typing import Optional, assert_never
+from requests.exceptions import ConnectionError
 
 GuestType = Config.GuestType
 
@@ -313,7 +314,11 @@ class Balancing:
         Returns:
             bool: True if the job entered an error state (FAILED or timed out), False otherwise.
         """
-        status = Balancing._get_rebalancing_job_status(proxmox_api, job)
+        try:
+            status = Balancing._get_rebalancing_job_status(proxmox_api, job)
+        except ConnectionError as exc:
+            logger.warning(str(exc))
+            status = None
         if status == Balancing.BalancingStatus.FINISHED:
             jobs_to_wait.remove(job)
             return False


### PR DESCRIPTION
For some reason PVE is flaky with status queries made by Balancing._get_rebalancing_job_status and raises an Exception. Now we retry in such case.

```
DEBUG - Starting: _get_rebalancing_job_status.
WARNING - ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response')) DEBUG - Starting: _get_rebalancing_job_status.
DEBUG - Balancing: ...
DEBUG - Balancing: ...
DEBUG - Finished: _get_rebalancing_job_status.
```