### PR TITLE
Fix qmigrate job tracking

### DIFF
--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -18,8 +18,13 @@ from proxlb.utils.config_parser import Config
 from proxlb.utils.proxlb_data import ProxLbData
 from pydantic import BaseModel
 from enum import Enum
-from typing import Optional, assert_never
+from typing import TYPE_CHECKING, Optional, assert_never
 from requests.exceptions import ConnectionError
+
+if TYPE_CHECKING:
+    from proxmoxer_types.v9.core import ProxmoxAPI
+    TaskListEntry = ProxmoxAPI.Nodes.Node.Tasks._Get.TypedDict
+    TaskStatus = ProxmoxAPI.Nodes.Node.Tasks.Upid.Status._Get.TypedDict
 
 GuestType = Config.GuestType
 
@@ -78,6 +83,8 @@ class Balancing:
         current_node: str
         job_id: str
         retry_counter: int = 0
+        resolved_job_id: Optional[str] = None
+        hamigrate_starttime: Optional[int] = None
 
     @staticmethod
     def balance(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData) -> bool:
@@ -355,49 +362,103 @@ class Balancing:
             BalancingStatus: RUNNING, FINISHED, or FAILED.
         """
         logger.debug("Starting: _get_rebalancing_job_status.")
+
+        if job.resolved_job_id is not None:
+            task: 'TaskStatus' = proxmox_api.nodes(job.current_node).tasks(job.resolved_job_id).status().get()
+            return Balancing._interpret_task_status(task, job.resolved_job_id, job.name)
+
         task = proxmox_api.nodes(job.current_node).tasks(job.job_id).status().get()
-        job_id = job.job_id
 
-        # Fetch actual migration job status if this got spawned by a HA job
-        if task["type"] == "hamigrate":
+        if task["type"] != "hamigrate":
             logger.debug(
-                f"Balancing: Job ID {job.job_id} (guest: {job.name}) "
-                "is a HA migration job. Fetching underlying migration job...")
-            time.sleep(1)
-            vm_id = job.id
-            qm_migrate_jobs = proxmox_api.nodes(job.current_node).tasks.get(
-                typefilter="qmigrate", vmid=vm_id, start=0, source="active", limit=1)
-
-            if len(qm_migrate_jobs) > 0:
-                task = qm_migrate_jobs[0]
-                job_id = task["upid"]
-                logger.debug(f"Overwriting job polling for: ID {job_id} (guest: {job.name}) by {task}")
-        else:
-            logger.debug(
-                f"Balancing: Job ID {job_id} (guest: {job.name}) is a standard migration job. "
+                f"Balancing: Job ID {job.job_id} (guest: {job.name}) is a standard migration job. "
                 "Proceeding with status check.")
+            return Balancing._interpret_task_status(task, job.job_id, job.name)
 
-        # Note: unsaved jobs are delivered in uppercase from the Proxmox API
-        task_status = task.get("status", "").lower()
-        if task_status == "running":
-            logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) for migration is still running...")
+        if task["status"] == "running":
+            logger.debug(
+                f"Balancing: HA migration request {job.job_id} (guest: {job.name}) "
+                "is still being processed by the HA manager...")
             return Balancing.BalancingStatus.RUNNING
 
-        if task_status == "stopped":
-            if task.get("exitstatus", "") == "OK":
-                logger.debug(f"Balancing: Job ID {job_id} (guest: {job.name}) was successfully.")
-                logger.debug("Finished: _get_rebalancing_job_status.")
-                return Balancing.BalancingStatus.FINISHED
-            else:
-                logger.critical(
-                    f"Balancing: Job ID {job_id} (guest: {job.name}) went into an error! "
-                    "Please check manually.")
-                logger.debug("Finished: _get_rebalancing_job_status.")
-                return Balancing.BalancingStatus.FAILED
+        if task.get("exitstatus") != "OK":
+            logger.critical(
+                f"Balancing: HA migration request {job.job_id} (guest: {job.name}) "
+                f"was rejected by the HA manager: {task.get('exitstatus')!r}. "
+                "Please check manually.")
+            return Balancing.BalancingStatus.FAILED
 
-        raise AssertionError(
-            f"Balancing: Unexpected status for Job ID {job_id} (guest: {job.name}): "
-            f"{task.get('status', '')}. Please check manually.")
+        if job.hamigrate_starttime is None:
+            job.hamigrate_starttime = task["starttime"]
+
+        qm_task = Balancing._find_qmigrate_task(proxmox_api, job)
+        if qm_task is None:
+            logger.debug(
+                f"Balancing: HA migration request {job.job_id} (guest: {job.name}) "
+                "was accepted but the underlying qmigrate task is not visible yet. Waiting...")
+            return Balancing.BalancingStatus.RUNNING
+
+        job.resolved_job_id = qm_task["upid"]
+        logger.debug(
+            f"Balancing: Resolved hamigrate {job.job_id} to qmigrate "
+            f"{job.resolved_job_id} for guest {job.name}.")
+
+        task = proxmox_api.nodes(job.current_node).tasks(job.resolved_job_id).status().get()
+        return Balancing._interpret_task_status(task, job.resolved_job_id, job.name)
+
+    @staticmethod
+    def _find_qmigrate_task(
+            proxmox_api: ProxmoxApi,
+            job: 'Balancing.RebalancingJob',
+    ) -> Optional['TaskListEntry']:
+        """
+        Looks up the qmigrate task spawned by the HA manager for this job's VM.
+
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            job (RebalancingJob): The job whose qmigrate task to find.
+
+        Returns:
+            Optional[TaskListEntry]: The matching task entry (its ``upid`` field
+            is pinned onto the job by the caller) or None if the qmigrate has not
+            appeared yet.
+        """
+        vmid_str = str(job.id)
+        starttime = job.hamigrate_starttime or 0
+
+        qm_migrate_jobs: list['TaskListEntry'] = proxmox_api.nodes(job.current_node).tasks.get(
+            typefilter="qmigrate",
+            vmid=job.id,
+            since=starttime,
+            source="all",
+            start=0,
+            limit=10,
+        )
+        for candidate in qm_migrate_jobs:
+            if candidate["id"] == vmid_str and candidate["starttime"] >= starttime:
+                return candidate
+        return None
+
+    @staticmethod
+    def _interpret_task_status(
+            task: 'TaskStatus',
+            job_id: str,
+            guest_name: str,
+    ) -> 'Balancing.BalancingStatus':
+        if task["status"] == "running":
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) for migration is still running...")
+            return Balancing.BalancingStatus.RUNNING
+
+        if task.get("exitstatus") == "OK":
+            logger.debug(f"Balancing: Job ID {job_id} (guest: {guest_name}) was successfully.")
+            logger.debug("Finished: _get_rebalancing_job_status.")
+            return Balancing.BalancingStatus.FINISHED
+
+        logger.critical(
+            f"Balancing: Job ID {job_id} (guest: {guest_name}) went into an error! "
+            "Please check manually.")
+        logger.debug("Finished: _get_rebalancing_job_status.")
+        return Balancing.BalancingStatus.FAILED
 
     @staticmethod
     def get_parallel_job_limit(proxlb_data_meta_balancing: ProxLbData.Meta.Balancing) -> int:


### PR DESCRIPTION
The current code prematurely reports a finished migration when a hamigrate task has finished, but the subsequent qmigrate task has not begun yet.

Before:
```
2026-05-19 16:39:24,184 - ProxLB - INFO - Finished: Balancing loop for guests. All guests processed and migrations completed.
2026-05-19 16:39:24,236 - ProxLB - WARNING - [solver] active: step 1 failed — ['hundred-one', 'hundred-two'] did not reach expected node
```
After:
```
026-05-19 16:43:04,326 - ProxLB - INFO - [solver] active: executing plan — 1 step(s), 2 VM(s), max_step_retries=3
2026-05-19 16:43:04,326 - ProxLB - INFO - [solver] active: step 1 (retry=0) — hundred-one prox-dev-host-172-26-250-154→prox-dev-host-172-26-250-156, hundred-two prox-dev-host-172-26-250-154→prox-dev-host-172-26-250-152
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Starting: balance.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: Parallel balancing is enabled. Running with 5 parallel jobs.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: parallel_job_limit resolved to 5.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Starting: Balancing loop for guests.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Starting: _exec_rebalancing.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: Processing guest hundred for potential rebalancing.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: Guest hundred is already on the target node prox-dev-host-172-26-250-154 and will not be rebalanced.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Finished: _exec_rebalancing.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: job_id for hundred: None, jobs_to_wait len: 0
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Starting: _exec_rebalancing.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: Processing guest hundred-one for potential rebalancing.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Balancing: Balancing for guest hundred-one of type VM started.
2026-05-19 16:43:04,326 - ProxLB - DEBUG - Starting: _exec_rebalancing_vm.
2026-05-19 16:43:04,326 - ProxLB - INFO - Balancing: Starting to migrate VM guest hundred-one from prox-dev-host-172-26-250-154 to prox-dev-host-172-26-250-156.
2026-05-19 16:43:04,555 - ProxLB - DEBUG - Finished: _exec_rebalancing_vm.
2026-05-19 16:43:04,556 - ProxLB - DEBUG - Finished: _exec_rebalancing.
2026-05-19 16:43:04,556 - ProxLB - DEBUG - Balancing: job_id for hundred-one: 'UPID:prox-dev-host-172-26-250-154:0021D20B:0D777A88:6A0C76F8:hamigrate:101:root@pam:', jobs_to_wait len: 0
2026-05-19 16:43:04,556 - ProxLB - DEBUG - Starting: _exec_rebalancing.
2026-05-19 16:43:04,556 - ProxLB - DEBUG - Balancing: Processing guest hundred-two for potential rebalancing.
2026-05-19 16:43:04,556 - ProxLB - DEBUG - Balancing: Balancing for guest hundred-two of type VM started.
2026-05-19 16:43:04,556 - ProxLB - DEBUG - Starting: _exec_rebalancing_vm.
2026-05-19 16:43:04,556 - ProxLB - INFO - Balancing: Starting to migrate VM guest hundred-two from prox-dev-host-172-26-250-154 to prox-dev-host-172-26-250-152.
2026-05-19 16:43:04,899 - ProxLB - DEBUG - Finished: _exec_rebalancing_vm.
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Finished: _exec_rebalancing.
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Balancing: job_id for hundred-two: 'UPID:prox-dev-host-172-26-250-154:0021D20D:0D777AA1:6A0C76F8:hamigrate:102:root@pam:', jobs_to_wait len: 1
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Starting: _exec_rebalancing.
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Balancing: Processing guest hundred-three for potential rebalancing.
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Balancing: Guest hundred-three is already on the target node prox-dev-host-172-26-250-154 and will not be rebalanced.
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Finished: _exec_rebalancing.
2026-05-19 16:43:04,900 - ProxLB - DEBUG - Balancing: job_id for hundred-three: None, jobs_to_wait len: 2
2026-05-19 16:43:05,001 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:05,194 - ProxLB - DEBUG - Balancing: HA migration request UPID:prox-dev-host-172-26-250-154:0021D20B:0D777A88:6A0C76F8:hamigrate:101:root@pam: (guest: hundred-one) is still being processed by the HA manager...
2026-05-19 16:43:05,295 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:05,482 - ProxLB - DEBUG - Balancing: HA migration request UPID:prox-dev-host-172-26-250-154:0021D20D:0D777AA1:6A0C76F8:hamigrate:102:root@pam: (guest: hundred-two) is still being processed by the HA manager...
2026-05-19 16:43:10,583 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:10,899 - ProxLB - DEBUG - Balancing: HA migration request UPID:prox-dev-host-172-26-250-154:0021D20B:0D777A88:6A0C76F8:hamigrate:101:root@pam: (guest: hundred-one) was accepted but the underlying qmigrate task is not visible yet. Waiting...
2026-05-19 16:43:10,999 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:11,220 - ProxLB - DEBUG - Balancing: HA migration request UPID:prox-dev-host-172-26-250-154:0021D20D:0D777AA1:6A0C76F8:hamigrate:102:root@pam: (guest: hundred-two) was accepted but the underlying qmigrate task is not visible yet. Waiting...
2026-05-19 16:43:16,321 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:16,648 - ProxLB - DEBUG - Balancing: HA migration request UPID:prox-dev-host-172-26-250-154:0021D20B:0D777A88:6A0C76F8:hamigrate:101:root@pam: (guest: hundred-one) was accepted but the underlying qmigrate task is not visible yet. Waiting...
2026-05-19 16:43:16,749 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:17,085 - ProxLB - DEBUG - Balancing: HA migration request UPID:prox-dev-host-172-26-250-154:0021D20D:0D777AA1:6A0C76F8:hamigrate:102:root@pam: (guest: hundred-two) was accepted but the underlying qmigrate task is not visible yet. Waiting...
2026-05-19 16:43:22,186 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:22,534 - ProxLB - DEBUG - Balancing: Resolved hamigrate UPID:prox-dev-host-172-26-250-154:0021D20B:0D777A88:6A0C76F8:hamigrate:101:root@pam: to qmigrate UPID:prox-dev-host-172-26-250-154:0021D234:0D777F69:6A0C7704:qmigrate:101:root@pam: for guest hundred-one.
2026-05-19 16:43:22,593 - ProxLB - DEBUG - Balancing: Job ID UPID:prox-dev-host-172-26-250-154:0021D234:0D777F69:6A0C7704:qmigrate:101:root@pam: (guest: hundred-one) for migration is still running...
2026-05-19 16:43:22,694 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:23,028 - ProxLB - DEBUG - Balancing: Resolved hamigrate UPID:prox-dev-host-172-26-250-154:0021D20D:0D777AA1:6A0C76F8:hamigrate:102:root@pam: to qmigrate UPID:prox-dev-host-172-26-250-154:0021D235:0D777F69:6A0C7704:qmigrate:102:root@pam: for guest hundred-two.
2026-05-19 16:43:23,100 - ProxLB - DEBUG - Balancing: Job ID UPID:prox-dev-host-172-26-250-154:0021D235:0D777F69:6A0C7704:qmigrate:102:root@pam: (guest: hundred-two) for migration is still running...
2026-05-19 16:43:28,202 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:28,355 - ProxLB - DEBUG - Balancing: Job ID UPID:prox-dev-host-172-26-250-154:0021D234:0D777F69:6A0C7704:qmigrate:101:root@pam: (guest: hundred-one) for migration is still running...
2026-05-19 16:43:28,456 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:28,629 - ProxLB - DEBUG - Balancing: Job ID UPID:prox-dev-host-172-26-250-154:0021D235:0D777F69:6A0C7704:qmigrate:102:root@pam: (guest: hundred-two) for migration is still running...
2026-05-19 16:43:33,731 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:33,920 - ProxLB - DEBUG - Balancing: Job ID UPID:prox-dev-host-172-26-250-154:0021D234:0D777F69:6A0C7704:qmigrate:101:root@pam: (guest: hundred-one) was successfully.
2026-05-19 16:43:33,920 - ProxLB - DEBUG - Finished: _get_rebalancing_job_status.
2026-05-19 16:43:34,021 - ProxLB - DEBUG - Starting: _get_rebalancing_job_status.
2026-05-19 16:43:34,214 - ProxLB - DEBUG - Balancing: Job ID UPID:prox-dev-host-172-26-250-154:0021D235:0D777F69:6A0C7704:qmigrate:102:root@pam: (guest: hundred-two) was successfully.
2026-05-19 16:43:34,215 - ProxLB - DEBUG - Finished: _get_rebalancing_job_status.
2026-05-19 16:43:34,215 - ProxLB - INFO - Finished: Balancing loop for guests. All guests processed and migrations completed.
2026-05-19 16:43:34,357 - ProxLB - INFO - [solver] active: step 1 succeeded (2 VM(s) migrated)
2026-05-19 16:43:34,357 - ProxLB - INFO - [solver] active: complete — 0 re-solve(s), all VMs placed successfully
