### PR TITLE
Make max_node_inflow compatible with current solver

### DIFF
--- a/proxlb/utils/config_parser.py
+++ b/proxlb/utils/config_parser.py
@@ -110,7 +110,7 @@ class Config(BaseModel):
         enforce_pinning: bool = False
         live: bool = True
         max_job_validation: int = 1800
-        max_node_inflow: Optional[int] = None
+        max_node_inflow: Optional[int] = 1
         memory_threshold: Optional[int] = None
         disk_threshold: Optional[int] = None
         method: "Config.Balancing.Resource" = Resource.Memory


### PR DESCRIPTION
proxlb-solver currently does not allow max_node_inflow=None. Users could add max_node_inflow=1 to their proxlb.yaml, but a ProxLb upgrade should not break their setup.

For now: Make max_node_inflow=1 a ProxLb default.
For later: Allow max_node_inflow=None in proxlb-solver, so that users may explicitly set it to null in their proxlb.yaml.