### PR TITLE
feat(balancing): remap target storage on node-local storage clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ The following options can be set in the configuration file `proxlb.yaml`:
 |  | live |  | True | `Bool` | If guests should be moved live or shutdown.|
 |  | with_local_disks |  | True | `Bool` | If balancing of guests should include local disks.|
 |  | with_conntrack_state |  | True | `Bool` | If balancing of guests should including the conntrack state.|
+|  | target_storage_auto |  | False | `Bool` | For node-local (non-shared) storage clusters: auto-pick a storage on the target node (most free space, matching content type) when the source storage id does not exist there.|
+|  | target_storage_map |  |  | `Dict` | Optional mapping of target node name to storage id, overriding `target_storage_auto`. e.g. `{pve5: local}`.|
 |  | balance_types |  | ['vm', 'ct'] | `List` | Defined the types of guests that should be honored. [values: `vm`, `ct`]|
 |  | max_job_validation |  | 1800 | `Int` | How long a job validation may take in seconds. (default: 1800) |
 |  | balanciness |  | 10 | `Int` | The maximum delta of resource usage between node with highest and lowest usage. |

--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ The following options can be set in the configuration file `proxlb.yaml`:
 |  | live |  | True | `Bool` | If guests should be moved live or shutdown.|
 |  | with_local_disks |  | True | `Bool` | If balancing of guests should include local disks.|
 |  | with_conntrack_state |  | True | `Bool` | If balancing of guests should including the conntrack state.|
-|  | target_storage_auto |  | False | `Bool` | For node-local (non-shared) storage clusters: auto-pick a storage on the target node (most free space, matching content type) when the source storage id does not exist there.|
-|  | target_storage_map |  |  | `Dict` | Optional mapping of target node name to storage id, overriding `target_storage_auto`. e.g. `{pve5: local}`.|
+|  | target_storage_auto |  | False | `Bool` | For node-local (non-shared) storage clusters: auto-pick a storage on the target node (most free space, matching content type) when the source storage id does not exist there. Note: HA-managed guests are skipped when a remap would apply, because Proxmox HA migrations do not honor a target storage.|
+|  | target_storage_map |  |  | `Dict` | Optional mapping of target node name to storage id, overriding `target_storage_auto`. e.g. `{pve5: local}`. The HA-managed guest limitation of `target_storage_auto` applies here as well.|
 |  | balance_types |  | ['vm', 'ct'] | `List` | Defined the types of guests that should be honored. [values: `vm`, `ct`]|
 |  | max_job_validation |  | 1800 | `Int` | How long a job validation may take in seconds. (default: 1800) |
 |  | balanciness |  | 10 | `Int` | The maximum delta of resource usage between node with highest and lowest usage. |

--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -33,6 +33,12 @@ balancing:
   live: True
   with_local_disks: True
   with_conntrack_state: True
+  # Target storage remapping for node-local (non-shared) storage clusters, where
+  # the source storage id may not exist on the target node. Disabled by default.
+  target_storage_auto: False          # Auto-pick the target-node storage with the most free space
+  # target_storage_map:               # Optional: pin a storage per target node (overrides auto)
+  #   pve5: local
+  #   pve2: local
   cpu_overcommit: 2.0                 # Maximum ratio of vCPUs to physical cores per node
   max_node_inflow: 1                  # Maximum number of VMs that may be migrated onto any single node per run
   balance_types: ['vm', 'ct']         # 'vm' | 'ct'

--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -35,6 +35,8 @@ balancing:
   with_conntrack_state: True
   # Target storage remapping for node-local (non-shared) storage clusters, where
   # the source storage id may not exist on the target node. Disabled by default.
+  # Note: HA-managed guests are skipped when a remap would apply, because the
+  # Proxmox HA stack does not forward the target storage to the migration task.
   target_storage_auto: False          # Auto-pick the target-node storage with the most free space
   # target_storage_map:               # Optional: pin a storage per target node (overrides auto)
   #   pve5: local

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -199,6 +199,67 @@ class Balancing:
         return job_id
 
     @staticmethod
+    def _resolve_target_storage(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData,
+                                target_node: str, content: str) -> Optional[str]:
+        """
+        Resolves a storage on the target node for guests living on node-local
+        (non-shared) storage, whose source storage id may not exist on the target.
+
+        Resolution order:
+            1. an explicit mapping from the config (balancing.target_storage_map);
+            2. if balancing.target_storage_auto is enabled, the active and enabled
+               storage on the target node that accepts the given content type and
+               has the most free space;
+            3. otherwise None, keeping Proxmox' default behaviour (same storage id
+               as the source), which is correct for shared-storage clusters.
+
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            proxlb_data (ProxLbData): ProxLB load balancing data.
+            target_node (str): The node the guest is being migrated to.
+            content (str): The required storage content type ('images' for VMs,
+                'rootdir' for CTs).
+
+        Returns:
+            Optional[str]: The resolved target storage id, or None.
+        """
+        balancing = proxlb_data.meta.balancing
+
+        storage_map = balancing.target_storage_map or {}
+        if target_node in storage_map:
+            return storage_map[target_node]
+
+        if not balancing.target_storage_auto:
+            return None
+
+        try:
+            storages = proxmox_api.nodes(target_node).storage.get()
+        except proxmoxer.core.ResourceException as proxmox_api_error:
+            logger.debug(
+                f"Balancing: could not enumerate storages on node {target_node}: "
+                f"{proxmox_api_error}")
+            return None
+
+        candidates = [
+            storage for storage in storages
+            if int(storage.get("active", 0)) == 1
+            and int(storage.get("enabled", 1)) == 1
+            and content in (storage.get("content") or "")
+            and storage.get("avail") is not None
+        ]
+        if not candidates:
+            logger.debug(
+                f"Balancing: no active '{content}' storage found on node "
+                f"{target_node}; keeping source storage id.")
+            return None
+
+        target_storage = max(candidates, key=lambda storage: int(storage.get("avail", 0)))
+        logger.debug(
+            f"Balancing: selected target storage '{target_storage['storage']}' on node "
+            f"{target_node} ({int(target_storage.get('avail', 0)) // (1024 ** 3)} GiB free).")
+        return target_storage["storage"]
+
+    @staticmethod
     def _exec_rebalancing_vm(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData, guest_name: str) -> Optional[str]:
         """
         Executes the rebalancing of a virtual machine (VM) to a new node within the cluster.
@@ -230,6 +291,13 @@ class Balancing:
         # PVE versions, so we should not add it by default.
         if proxlb_data.meta.balancing.with_conntrack_state:
             migration_options['with-conntrack-state'] = 1
+
+        # On node-local storage clusters the source storage id may not exist on
+        # the target node. Remap to a suitable target storage when configured.
+        target_storage = Balancing._resolve_target_storage(
+            proxmox_api, proxlb_data, guest_node_target, "images")
+        if target_storage:
+            migration_options['targetstorage'] = target_storage
 
         try:
             logger.info(
@@ -266,12 +334,26 @@ class Balancing:
         guest_node_target = proxlb_data.guests[guest_name].node_target
         job_id = None
 
+        ct_migration_options = {
+            'target': guest_node_target,
+            'restart': 1,
+        }
+
+        # On node-local storage clusters the source storage id may not exist on
+        # the target node. Remap to a suitable target storage when configured.
+        # Note: LXC migration uses 'target-storage' (hyphenated) where QEMU uses
+        # 'targetstorage'.
+        target_storage = Balancing._resolve_target_storage(
+            proxmox_api, proxlb_data, guest_node_target, "rootdir")
+        if target_storage:
+            ct_migration_options['target-storage'] = target_storage
+
         try:
             logger.info(
                 f"Balancing: Starting to migrate CT guest {guest_name} "
                 f"from {guest_node_current} to {guest_node_target}.")
             job_id = proxmox_api.nodes(guest_node_current).lxc(guest_id).migrate().post(
-                target=guest_node_target, restart=1)
+                **ct_migration_options)
         except proxmoxer.core.ResourceException as proxmox_api_error:
             logger.critical(
                 f"Balancing: Failed to migrate guest {guest_name} of type CT due to some Proxmox errors. "

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from proxmoxer_types.v9.core import ProxmoxAPI
     TaskListEntry = ProxmoxAPI.Nodes.Node.Tasks._Get.TypedDict
     TaskStatus = ProxmoxAPI.Nodes.Node.Tasks.Upid.Status._Get.TypedDict
+    Storages = list[ProxmoxAPI.Nodes.Node.Storage._Get.TypedDict]
 
 GuestType = Config.GuestType
 
@@ -233,7 +234,7 @@ class Balancing:
             return None
 
         try:
-            storages = proxmox_api.nodes(target_node).storage.get()
+            storages: 'Storages' = proxmox_api.nodes(target_node).storage.get()
         except proxmoxer.core.ResourceException as proxmox_api_error:
             logger.debug(
                 f"Balancing: could not enumerate storages on node {target_node}: "
@@ -242,9 +243,9 @@ class Balancing:
 
         candidates = [
             storage for storage in storages
-            if int(storage.get("active", 0)) == 1
-            and int(storage.get("enabled", 1)) == 1
-            and content in (storage.get("content") or "")
+            if storage.get("active", 0) == 1
+            and storage.get("enabled", 1) == 1
+            and content in storage.get("content", "").split(",")
             and storage.get("avail") is not None
         ]
         if not candidates:
@@ -253,10 +254,10 @@ class Balancing:
                 f"{target_node}; keeping source storage id.")
             return None
 
-        target_storage = max(candidates, key=lambda storage: int(storage.get("avail", 0)))
+        target_storage = max(candidates, key=lambda storage: storage.get("avail") or 0)
         logger.debug(
             f"Balancing: selected target storage '{target_storage['storage']}' on node "
-            f"{target_node} ({int(target_storage.get('avail', 0)) // (1024 ** 3)} GiB free).")
+            f"{target_node} ({(target_storage.get('avail') or 0) // (1024 ** 3)} GiB free).")
         return target_storage["storage"]
 
     @staticmethod

--- a/proxlb/models/balancing.py
+++ b/proxlb/models/balancing.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     TaskListEntry = ProxmoxAPI.Nodes.Node.Tasks._Get.TypedDict
     TaskStatus = ProxmoxAPI.Nodes.Node.Tasks.Upid.Status._Get.TypedDict
     Storages = list[ProxmoxAPI.Nodes.Node.Storage._Get.TypedDict]
+    HaResources = list[ProxmoxAPI.Cluster.Ha.Resources._Get.TypedDict]
 
 GuestType = Config.GuestType
 
@@ -106,6 +107,9 @@ class Balancing:
         logger.debug("Starting: balance.")
         parallel_job_limit = Balancing.get_parallel_job_limit(proxlb_data.meta.balancing)
         logger.debug(f"Balancing: parallel_job_limit resolved to {parallel_job_limit}.")
+
+        # Reset the HA-managed resource cache for this pass.
+        proxlb_data.meta.balancing.ha_managed_sids = None
 
         jobs_to_wait: list[Balancing.RebalancingJob] = []
         max_retries = proxlb_data.meta.balancing.max_job_validation
@@ -198,6 +202,42 @@ class Balancing:
 
         logger.debug("Finished: _exec_rebalancing.")
         return job_id
+
+    @staticmethod
+    def _is_ha_managed(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData,
+                       sid_prefix: str, guest_id: int) -> bool:
+        """
+        Checks whether a guest is managed by the Proxmox HA manager. The HA
+        resource list is fetched once per balancing pass and cached, since the
+        answer is needed for every guest whose target storage would be remapped.
+
+        This matters for the target storage remap: migrations of HA-managed
+        guests are routed through the HA stack (hamigrate), which does not
+        forward the 'targetstorage' / 'target-storage' parameter to the
+        underlying migration task. On node-local storage clusters that task
+        then fails with "storage 'X' is not available on node 'Y'", so such
+        guests must be skipped instead of migrated with a remap.
+
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            proxlb_data (ProxLbData): ProxLB load balancing data.
+            sid_prefix (str): The HA service id prefix ('vm' or 'ct').
+            guest_id (int): The guest's vmid.
+
+        Returns:
+            bool: True if the guest is an HA-managed resource.
+        """
+        balancing = proxlb_data.meta.balancing
+        if balancing.ha_managed_sids is None:
+            try:
+                ha_resources: 'HaResources' = proxmox_api.cluster.ha.resources.get()
+                balancing.ha_managed_sids = [resource["sid"] for resource in ha_resources]
+            except proxmoxer.core.ResourceException as proxmox_api_error:
+                logger.debug(
+                    f"Balancing: could not list HA resources: {proxmox_api_error}. "
+                    "Assuming no guest is HA-managed.")
+                balancing.ha_managed_sids = []
+        return f"{sid_prefix}:{guest_id}" in balancing.ha_managed_sids
 
     @staticmethod
     def _resolve_target_storage(proxmox_api: ProxmoxApi, proxlb_data: ProxLbData,
@@ -298,6 +338,17 @@ class Balancing:
         target_storage = Balancing._resolve_target_storage(
             proxmox_api, proxlb_data, guest_node_target, "images")
         if target_storage:
+            # The HA stack does not forward 'targetstorage' to the qmigrate task
+            # it spawns, which would then fail with "storage 'X' is not available
+            # on node 'Y'". Skip HA-managed guests instead of remapping them.
+            if Balancing._is_ha_managed(proxmox_api, proxlb_data, "vm", guest_id):
+                logger.warning(
+                    f"Balancing: Skipping migration of VM guest {guest_name} to "
+                    f"{guest_node_target}: the guest is HA-managed and Proxmox does not "
+                    f"apply a target storage remap (targetstorage '{target_storage}') to "
+                    "HA migrations. Remove the guest from HA or migrate it manually.")
+                logger.debug("Finished: _exec_rebalancing_vm.")
+                return None
             migration_options['targetstorage'] = target_storage
 
         try:
@@ -347,6 +398,17 @@ class Balancing:
         target_storage = Balancing._resolve_target_storage(
             proxmox_api, proxlb_data, guest_node_target, "rootdir")
         if target_storage:
+            # The HA stack does not forward 'target-storage' to the migration task
+            # it spawns, which would then fail with "storage 'X' is not available
+            # on node 'Y'". Skip HA-managed guests instead of remapping them.
+            if Balancing._is_ha_managed(proxmox_api, proxlb_data, "ct", guest_id):
+                logger.warning(
+                    f"Balancing: Skipping migration of CT guest {guest_name} to "
+                    f"{guest_node_target}: the guest is HA-managed and Proxmox does not "
+                    f"apply a target storage remap (target-storage '{target_storage}') to "
+                    "HA migrations. Remove the guest from HA or migrate it manually.")
+                logger.debug("Finished: _exec_rebalancing_ct.")
+                return None
             ct_migration_options['target-storage'] = target_storage
 
         try:

--- a/proxlb/models/tests/test_balancing_ha_target_storage.py
+++ b/proxlb/models/tests/test_balancing_ha_target_storage.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for the HA-managed guest handling of the target storage remap.
+
+Migrations of HA-managed guests are routed through the Proxmox HA stack
+(hamigrate), which does not forward the 'targetstorage' / 'target-storage'
+parameter to the migration task it spawns. On node-local storage clusters that
+task then fails with "storage 'X' is not available on node 'Y'". These tests
+verify that guests are skipped when a remap would apply to an HA-managed
+guest, that non-HA guests still receive the remap, and that the HA resource
+list is fetched once per pass and degrades safely on API errors.
+"""
+
+__author__ = "YorkHost"
+__license__ = "GPL-3.0"
+
+
+import proxmoxer
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+from proxlb.models.balancing import Balancing
+
+
+def _guest(guest_id: int) -> MagicMock:
+    g = MagicMock()
+    g.id = guest_id
+    g.name = f"guest-{guest_id}"
+    g.node_current = "node1"
+    g.node_target = "node2"
+    return g
+
+
+def _proxlb_data(guest_name: str, guest: MagicMock) -> MagicMock:
+    data = MagicMock()
+    data.meta.balancing.live = True
+    data.meta.balancing.with_local_disks = True
+    data.meta.balancing.with_conntrack_state = False
+    data.meta.balancing.ha_managed_sids = None
+    data.guests = {guest_name: guest}
+    return data
+
+
+def _api(ha_sids: Optional[list[str]] = None) -> MagicMock:
+    api = MagicMock()
+    api.cluster.ha.resources.get.return_value = [{"sid": sid} for sid in (ha_sids or [])]
+    return api
+
+
+@patch.object(Balancing, "_resolve_target_storage", return_value="local")
+def test_ha_managed_vm_with_remap_is_skipped(mock_resolve: MagicMock) -> None:
+    """A remap on an HA-managed VM must skip the migration entirely."""
+    api = _api(["vm:101"])
+    data = _proxlb_data("vm1", _guest(101))
+
+    job_id = Balancing._exec_rebalancing_vm(api, data, "vm1")
+
+    assert job_id is None
+    api.nodes.return_value.qemu.return_value.migrate.return_value.post.assert_not_called()
+
+
+@patch.object(Balancing, "_resolve_target_storage", return_value="local")
+def test_non_ha_vm_with_remap_migrates_with_targetstorage(mock_resolve: MagicMock) -> None:
+    """A non-HA VM must be migrated with the resolved 'targetstorage'."""
+    api = _api(["vm:999"])  # some other guest is HA-managed
+    data = _proxlb_data("vm1", _guest(101))
+
+    job_id = Balancing._exec_rebalancing_vm(api, data, "vm1")
+
+    post = api.nodes.return_value.qemu.return_value.migrate.return_value.post
+    post.assert_called_once()
+    assert post.call_args.kwargs["targetstorage"] == "local"
+    assert job_id is not None
+
+
+@patch.object(Balancing, "_resolve_target_storage", return_value=None)
+def test_ha_managed_vm_without_remap_migrates_normally(mock_resolve: MagicMock) -> None:
+    """Without a remap, HA-managed guests keep the default migration behaviour."""
+    api = _api(["vm:101"])
+    data = _proxlb_data("vm1", _guest(101))
+
+    Balancing._exec_rebalancing_vm(api, data, "vm1")
+
+    post = api.nodes.return_value.qemu.return_value.migrate.return_value.post
+    post.assert_called_once()
+    assert "targetstorage" not in post.call_args.kwargs
+    api.cluster.ha.resources.get.assert_not_called()
+
+
+@patch.object(Balancing, "_resolve_target_storage", return_value="local")
+def test_ha_managed_ct_with_remap_is_skipped(mock_resolve: MagicMock) -> None:
+    """A remap on an HA-managed CT must skip the migration entirely."""
+    api = _api(["ct:201"])
+    data = _proxlb_data("ct1", _guest(201))
+
+    job_id = Balancing._exec_rebalancing_ct(api, data, "ct1")
+
+    assert job_id is None
+    api.nodes.return_value.lxc.return_value.migrate.return_value.post.assert_not_called()
+
+
+@patch.object(Balancing, "_resolve_target_storage", return_value="local")
+def test_non_ha_ct_with_remap_migrates_with_target_storage(mock_resolve: MagicMock) -> None:
+    """A non-HA CT must be migrated with the resolved 'target-storage'."""
+    api = _api([])
+    data = _proxlb_data("ct1", _guest(201))
+
+    Balancing._exec_rebalancing_ct(api, data, "ct1")
+
+    post = api.nodes.return_value.lxc.return_value.migrate.return_value.post
+    post.assert_called_once()
+    assert post.call_args.kwargs["target-storage"] == "local"
+
+
+def test_ha_resources_fetched_once_per_pass() -> None:
+    """The HA resource list must be fetched lazily and cached for the pass."""
+    api = _api(["vm:1"])
+    data = MagicMock()
+    data.meta.balancing.ha_managed_sids = None
+
+    assert Balancing._is_ha_managed(api, data, "vm", 1) is True
+    assert Balancing._is_ha_managed(api, data, "vm", 2) is False
+    assert Balancing._is_ha_managed(api, data, "ct", 1) is False
+    api.cluster.ha.resources.get.assert_called_once()
+
+
+def test_ha_resources_error_assumes_not_managed() -> None:
+    """An API error while listing HA resources must degrade to 'not HA-managed'."""
+    api = MagicMock()
+    api.cluster.ha.resources.get.side_effect = proxmoxer.core.ResourceException(
+        500, "Internal Server Error", "boom")
+    data = MagicMock()
+    data.meta.balancing.ha_managed_sids = None
+
+    assert Balancing._is_ha_managed(api, data, "vm", 1) is False
+    # the failed lookup is cached as an empty list, not retried per guest
+    assert Balancing._is_ha_managed(api, data, "vm", 2) is False
+    assert api.cluster.ha.resources.get.call_count == 1

--- a/proxlb/models/tests/test_balancing_resolve_target_storage.py
+++ b/proxlb/models/tests/test_balancing_resolve_target_storage.py
@@ -7,25 +7,30 @@ selection by free space and content type, and the safe fall-through to None
 (keeping Proxmox' default same-storage-id behaviour).
 """
 
-__author__ = "Peter Dreuw <archandha>"
-__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__author__ = "YorkHost"
 __license__ = "GPL-3.0"
 
 
 import proxmoxer
+from typing import TYPE_CHECKING, Optional
 from unittest.mock import MagicMock
 
 from proxlb.models.balancing import Balancing
 
+if TYPE_CHECKING:
+    from proxmoxer_types.v9.core import ProxmoxAPI
+    Storages = list[ProxmoxAPI.Nodes.Node.Storage._Get.TypedDict]
 
-def _proxlb_data(target_storage_auto: bool = False, target_storage_map=None) -> MagicMock:
+
+def _proxlb_data(target_storage_auto: bool = False,
+                 target_storage_map: Optional[dict[str, str]] = None) -> MagicMock:
     data = MagicMock()
     data.meta.balancing.target_storage_auto = target_storage_auto
     data.meta.balancing.target_storage_map = target_storage_map
     return data
 
 
-def _api(storages) -> MagicMock:
+def _api(storages: 'Storages') -> MagicMock:
     """Build a proxmox_api mock whose nodes(x).storage.get() returns `storages`."""
     api = MagicMock()
     api.nodes.return_value.storage.get.return_value = storages
@@ -56,12 +61,12 @@ def test_disabled_returns_none() -> None:
 
 def test_auto_picks_storage_with_most_free_space() -> None:
     """Auto mode must pick the active/enabled matching-content storage with most free space."""
-    storages = [
-        {"storage": "small", "active": 1, "enabled": 1, "content": "images,rootdir", "avail": 10},
-        {"storage": "big", "active": 1, "enabled": 1, "content": "images", "avail": 9000},
-        {"storage": "iso-only", "active": 1, "enabled": 1, "content": "iso", "avail": 99999},
-        {"storage": "inactive", "active": 0, "enabled": 1, "content": "images", "avail": 99999},
-        {"storage": "disabled", "active": 1, "enabled": 0, "content": "images", "avail": 99999},
+    storages: 'Storages' = [
+        {"storage": "small", "active": 1, "enabled": 1, "content": "images,rootdir", "avail": 10, "type": "dummy"},
+        {"storage": "big", "active": 1, "enabled": 1, "content": "images", "avail": 9000, "type": "dummy"},
+        {"storage": "iso-only", "active": 1, "enabled": 1, "content": "iso", "avail": 99999, "type": "dummy"},
+        {"storage": "inactive", "active": 0, "enabled": 1, "content": "images", "avail": 99999, "type": "dummy"},
+        {"storage": "disabled", "active": 1, "enabled": 0, "content": "images", "avail": 99999, "type": "dummy"},
     ]
     api = _api(storages)
     data = _proxlb_data(target_storage_auto=True)
@@ -73,9 +78,9 @@ def test_auto_picks_storage_with_most_free_space() -> None:
 
 def test_auto_rootdir_content_filter() -> None:
     """CT resolution must only consider storages advertising the rootdir content type."""
-    storages = [
-        {"storage": "vmonly", "active": 1, "enabled": 1, "content": "images", "avail": 9000},
-        {"storage": "ctstore", "active": 1, "enabled": 1, "content": "rootdir,images", "avail": 100},
+    storages: 'Storages' = [
+        {"storage": "vmonly", "active": 1, "enabled": 1, "content": "images", "avail": 9000, "type": "dummy"},
+        {"storage": "ctstore", "active": 1, "enabled": 1, "content": "rootdir,images", "avail": 100, "type": "dummy"},
     ]
     api = _api(storages)
     data = _proxlb_data(target_storage_auto=True)
@@ -85,10 +90,24 @@ def test_auto_rootdir_content_filter() -> None:
     assert result == "ctstore"
 
 
+def test_auto_content_match_is_token_based() -> None:
+    """Content matching must compare whole tokens, not substrings."""
+    storages: 'Storages' = [
+        {"storage": "trap", "active": 1, "enabled": 1, "content": "images-legacy", "avail": 9000, "type": "dummy"},
+        {"storage": "real", "active": 1, "enabled": 1, "content": "iso,images", "avail": 100, "type": "dummy"},
+    ]
+    api = _api(storages)
+    data = _proxlb_data(target_storage_auto=True)
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "images")
+
+    assert result == "real"
+
+
 def test_auto_no_candidate_returns_none() -> None:
     """Auto mode with no matching storage must fall through to None."""
-    storages = [
-        {"storage": "iso-only", "active": 1, "enabled": 1, "content": "iso", "avail": 9000},
+    storages: 'Storages' = [
+        {"storage": "iso-only", "active": 1, "enabled": 1, "content": "iso", "avail": 9000, "type": "dummy"},
     ]
     api = _api(storages)
     data = _proxlb_data(target_storage_auto=True)

--- a/proxlb/models/tests/test_balancing_resolve_target_storage.py
+++ b/proxlb/models/tests/test_balancing_resolve_target_storage.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for Balancing._resolve_target_storage().
+
+These tests cover the target storage resolution used when migrating guests that
+live on node-local (non-shared) storage: explicit per-node mapping, automatic
+selection by free space and content type, and the safe fall-through to None
+(keeping Proxmox' default same-storage-id behaviour).
+"""
+
+__author__ = "Peter Dreuw <archandha>"
+__copyright__ = "Copyright (C) 2026 Peter Dreuw (@archandha) for credativ GmbH"
+__license__ = "GPL-3.0"
+
+
+import proxmoxer
+from unittest.mock import MagicMock
+
+from proxlb.models.balancing import Balancing
+
+
+def _proxlb_data(target_storage_auto: bool = False, target_storage_map=None) -> MagicMock:
+    data = MagicMock()
+    data.meta.balancing.target_storage_auto = target_storage_auto
+    data.meta.balancing.target_storage_map = target_storage_map
+    return data
+
+
+def _api(storages) -> MagicMock:
+    """Build a proxmox_api mock whose nodes(x).storage.get() returns `storages`."""
+    api = MagicMock()
+    api.nodes.return_value.storage.get.return_value = storages
+    return api
+
+
+def test_map_takes_precedence_over_auto() -> None:
+    """An explicit per-node mapping must be returned without querying the API."""
+    api = _api([])
+    data = _proxlb_data(target_storage_auto=True, target_storage_map={"pve5": "local"})
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "images")
+
+    assert result == "local"
+    api.nodes.assert_not_called()
+
+
+def test_disabled_returns_none() -> None:
+    """With auto disabled and no mapping, resolution must return None (no remap)."""
+    api = _api([])
+    data = _proxlb_data(target_storage_auto=False, target_storage_map=None)
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "images")
+
+    assert result is None
+    api.nodes.assert_not_called()
+
+
+def test_auto_picks_storage_with_most_free_space() -> None:
+    """Auto mode must pick the active/enabled matching-content storage with most free space."""
+    storages = [
+        {"storage": "small", "active": 1, "enabled": 1, "content": "images,rootdir", "avail": 10},
+        {"storage": "big", "active": 1, "enabled": 1, "content": "images", "avail": 9000},
+        {"storage": "iso-only", "active": 1, "enabled": 1, "content": "iso", "avail": 99999},
+        {"storage": "inactive", "active": 0, "enabled": 1, "content": "images", "avail": 99999},
+        {"storage": "disabled", "active": 1, "enabled": 0, "content": "images", "avail": 99999},
+    ]
+    api = _api(storages)
+    data = _proxlb_data(target_storage_auto=True)
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "images")
+
+    assert result == "big"
+
+
+def test_auto_rootdir_content_filter() -> None:
+    """CT resolution must only consider storages advertising the rootdir content type."""
+    storages = [
+        {"storage": "vmonly", "active": 1, "enabled": 1, "content": "images", "avail": 9000},
+        {"storage": "ctstore", "active": 1, "enabled": 1, "content": "rootdir,images", "avail": 100},
+    ]
+    api = _api(storages)
+    data = _proxlb_data(target_storage_auto=True)
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "rootdir")
+
+    assert result == "ctstore"
+
+
+def test_auto_no_candidate_returns_none() -> None:
+    """Auto mode with no matching storage must fall through to None."""
+    storages = [
+        {"storage": "iso-only", "active": 1, "enabled": 1, "content": "iso", "avail": 9000},
+    ]
+    api = _api(storages)
+    data = _proxlb_data(target_storage_auto=True)
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "images")
+
+    assert result is None
+
+
+def test_api_error_returns_none() -> None:
+    """A Proxmox API error while listing storages must be swallowed and return None."""
+    api = MagicMock()
+    api.nodes.return_value.storage.get.side_effect = proxmoxer.core.ResourceException(
+        500, "Internal Server Error", "boom")
+    data = _proxlb_data(target_storage_auto=True)
+
+    result = Balancing._resolve_target_storage(api, data, "pve5", "images")
+
+    assert result is None

--- a/proxlb/utils/config_parser.py
+++ b/proxlb/utils/config_parser.py
@@ -122,6 +122,15 @@ class Config(BaseModel):
         psi: Optional[Psi] = None
         with_conntrack_state: bool = True
         with_local_disks: bool = True
+        # Target storage remapping for clusters built on node-local (non-shared)
+        # storage, where the source storage id may not exist on the target node.
+        # Disabled by default to preserve Proxmox' "same storage id" behaviour on
+        # shared-storage clusters. When 'target_storage_auto' is enabled, the
+        # storage with the most free space accepting the guest's content type is
+        # picked on the target node. 'target_storage_map' allows pinning a storage
+        # per target node and takes precedence over auto selection.
+        target_storage_auto: bool = False
+        target_storage_map: Optional[dict[str, str]] = None
 
         def threshold(self, method: "Config.Balancing.Resource") -> Optional[int]:
             if method == self.Resource.Cpu:

--- a/proxlb/utils/proxlb_data.py
+++ b/proxlb/utils/proxlb_data.py
@@ -20,6 +20,11 @@ class ProxLbData(BaseModel):
             balance_reason: str = 'resources'
             parallel_jobs: int = 5
             processed_guests_psi: list[str] = []
+            # Runtime-only: HA-managed resource sids (e.g. 'vm:100', 'ct:101'),
+            # fetched lazily once per balancing pass. None means "not fetched
+            # yet". Used to skip target storage remaps for HA-managed guests,
+            # since the HA stack does not forward the target storage parameter.
+            ha_managed_sids: Optional[list[str]] = None
 
         balancing: Balancing = Balancing()  # pyright: ignore [reportIncompatibleVariableOverride]
         cluster_non_pve9: bool


### PR DESCRIPTION
ProxLB always migrates keeping the source storage id. On clusters built on node-local (non-shared) storage, the source storage id often does not exist on the target node, so the migration is rejected by Proxmox at validation time ("storage 'X' is not available on node 'Y'") before any task is created.

Add optional target storage resolution:
- balancing.target_storage_auto (default False): pick the active/enabled storage on the target node accepting the guest content type ('images' for VMs, 'rootdir' for CTs) with the most free space.
- balancing.target_storage_map (optional): pin a storage per target node, taking precedence over auto selection.

VMs receive 'targetstorage', CTs receive 'target-storage'. Default behaviour is unchanged (both options off => no remap), preserving correctness on shared-storage clusters.

Adds unit tests for _resolve_target_storage and documents the options in the README and example config.