### PR TITLE
Prepare accounting for disk sizes of non-boot disks

### DIFF
--- a/proxlb/__main__.py
+++ b/proxlb/__main__.py
@@ -31,6 +31,7 @@ from proxlb.models.balancing import Balancing
 from proxlb.models.pools import Pools
 from proxlb.models.ha_rules import HaRules
 from proxlb.models.ha_status import HaStatus
+from proxlb.models.storage import Storage
 from proxlb.utils.helper import Helper
 from proxlb.utils.proxlb_data import ProxLbData
 
@@ -104,9 +105,10 @@ while True:
     Helper.apply_maintenance_nodes_schedule(proxlb_config)
     nodes = Nodes.get_nodes(proxmox_api, proxlb_config)
     meta = Features.validate_any_non_pve9_node(proxlb_config, nodes)
+    storage = Storage.get_storage(proxmox_api, nodes)
     pools = Pools.get_pools(proxmox_api)
     ha_rules = HaRules.get_ha_rules(proxmox_api, meta)
-    guests = Guests.get_guests(proxmox_api, pools, ha_rules, nodes, proxlb_config)
+    guests = Guests.get_guests(proxmox_api, pools, ha_rules, nodes, storage, proxlb_config)
     groups = Groups.get_groups(guests, nodes)
 
     # Merge obtained objects from the Proxmox cluster for further usage
@@ -117,6 +119,7 @@ while True:
         pools=pools,
         ha_rules=ha_rules,
         groups=groups,
+        storage=storage,
     )
     Helper.log_node_metrics(proxlb_data)
 

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -17,6 +17,7 @@ from proxlb.utils.rrd import GuestRrdKey, RrdDatasets
 from proxlb.models.pools import Pools
 from proxlb.models.ha_rules import HaRules
 from proxlb.models.ha_status import HaStatus
+from proxlb.models.storage import Storage
 from proxlb.models.tags import Tags
 import time
 
@@ -47,7 +48,7 @@ class Guests:
         """
 
     @staticmethod
-    def get_guests(proxmox_api: ProxmoxApi, pools: Dict[str, ProxLbData.Pool], ha_rules: Dict[str, ProxLbData.HaRule], nodes: Dict[str, ProxLbData.Node], proxlb_config: Config) -> Dict[str, ProxLbData.Guest]:
+    def get_guests(proxmox_api: ProxmoxApi, pools: Dict[str, ProxLbData.Pool], ha_rules: Dict[str, ProxLbData.HaRule], nodes: Dict[str, ProxLbData.Node], storage: Dict[str, ProxLbData.Storage], proxlb_config: Config) -> Dict[str, ProxLbData.Guest]:
         """
         Get metrics of all guests in a Proxmox cluster.
 
@@ -60,7 +61,7 @@ class Guests:
             pools (Dict[str, Any]): A dictionary containing information about the pools in the Proxmox cluster.
             ha_rules (Dict[str, Any]): A dictionary containing information about the HA rules in the
             nodes (Dict[str, Any]): A dictionary containing information about the nodes in the Proxmox cluster.
-            meta (Dict[str, Any]): A dictionary containing metadata information.
+            storage (Dict[str, Any]): A dictionary containing the storages collected by Storage.get_storage.
             proxmox_config (Dict[str, Any]): A dictionary containing the ProxLB configuration.
 
         Returns:
@@ -128,6 +129,7 @@ class Guests:
                         node_relationships=Tags.get_node_relationships(guest_tags, nodes, guest_pools, guest_ha_rules, proxlb_config),
                         node_relationships_strict=Pools.get_pool_node_affinity_strictness(proxlb_config, guest_pools),
                         type=GuestType.Vm,
+                        disks=Storage.get_disks_for_guest(guest['vmid'], storage),
                         ha_managed=f"vm:{guest['vmid']}" in ha_managed_sids,
                     )
 
@@ -189,6 +191,7 @@ class Guests:
                         node_relationships=Tags.get_node_relationships(guest_tags, nodes, guest_pools, guest_ha_rules, proxlb_config),
                         node_relationships_strict=Pools.get_pool_node_affinity_strictness(proxlb_config, guest_pools),
                         type=GuestType.Ct,
+                        disks=Storage.get_disks_for_guest(guest['vmid'], storage),
                         ha_managed=f"ct:{guest['vmid']}" in ha_managed_sids,
                     )
 

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -16,6 +16,7 @@ from proxlb.utils.proxlb_data import ProxLbData
 from proxlb.utils.rrd import GuestRrdKey, RrdDatasets
 from proxlb.models.pools import Pools
 from proxlb.models.ha_rules import HaRules
+from proxlb.models.ha_status import HaStatus
 from proxlb.models.tags import Tags
 import time
 
@@ -67,6 +68,7 @@ class Guests:
         """
         logger.debug("Starting: get_guests.")
         guests: Dict[str, ProxLbData.Guest] = {}
+        ha_managed_sids = HaStatus.get_ha_managed_sids(proxmox_api)
 
         # Guest objects are always only in the scope of a node.
         # Therefore, we need to iterate over all nodes to get all guests.
@@ -126,6 +128,7 @@ class Guests:
                         node_relationships=Tags.get_node_relationships(guest_tags, nodes, guest_pools, guest_ha_rules, proxlb_config),
                         node_relationships_strict=Pools.get_pool_node_affinity_strictness(proxlb_config, guest_pools),
                         type=GuestType.Vm,
+                        ha_managed=f"vm:{guest['vmid']}" in ha_managed_sids,
                     )
 
                     logger.debug(f"Resources of Guest {guest['name']} (type VM) added: {guests[guest['name']]}")
@@ -186,6 +189,7 @@ class Guests:
                         node_relationships=Tags.get_node_relationships(guest_tags, nodes, guest_pools, guest_ha_rules, proxlb_config),
                         node_relationships_strict=Pools.get_pool_node_affinity_strictness(proxlb_config, guest_pools),
                         type=GuestType.Ct,
+                        ha_managed=f"ct:{guest['vmid']}" in ha_managed_sids,
                     )
 
                     logger.debug(f"Resources of Guest {guest['name']} (type CT) added: {guests[guest['name']]}")

--- a/proxlb/models/ha_status.py
+++ b/proxlb/models/ha_status.py
@@ -66,6 +66,34 @@ class HaStatus:
         return str(ha_master_node)
 
     @staticmethod
+    def get_ha_managed_sids(proxmox_api: ProxmoxApi) -> set[str]:
+        """
+        Retrieve the service ids of all HA-managed resources in the cluster.
+
+        Queries /cluster/ha/resources and returns the sids (e.g. 'vm:100',
+        'ct:101'). An API error safely degrades to an empty set, i.e. no
+        guest is considered HA-managed.
+
+        Args:
+            proxmox_api (ProxmoxApi): Proxmox API client instance.
+
+        Returns:
+            set[str]: The sids of all HA-managed resources.
+        """
+        logger.debug("Starting: get_ha_managed_sids.")
+
+        try:
+            ha_resources = proxmox_api.cluster.ha.resources.get()
+        except Exception as proxmox_api_error:
+            logger.error(f"Failed to list HA resources: {proxmox_api_error}. Treating all guests as not HA-managed.")
+            return set()
+
+        ha_managed_sids = {str(resource["sid"]) for resource in ha_resources if resource.get("sid")}
+        logger.debug(f"HA-managed sids: {ha_managed_sids}")
+        logger.debug("Finished: get_ha_managed_sids.")
+        return ha_managed_sids
+
+    @staticmethod
     def is_node_ha_manager(proxmox_api: ProxmoxApi) -> bool:
         """
         Check if the local executing node is the HA manager.

--- a/proxlb/models/storage.py
+++ b/proxlb/models/storage.py
@@ -1,0 +1,162 @@
+"""
+The Storage class retrieves the storage topology of a Proxmox cluster and
+attributes guest disk usage to storages.
+
+It sweeps the node/storage matrix once: `nodes(*).storage.get()` provides the
+per-node capacity and availability of every storage, and
+`nodes(*).storage(*).content.get()` provides the volumes owned by each guest.
+Shared storages are content-listed only once (they are a single instance),
+node-local storages once per node instance. Only content types belonging to
+guests ('images' for VMs, 'rootdir' for CTs) are requested, so storages that
+hold only backups, ISOs or templates are never content-listed at all.
+"""
+
+import time
+from typing import TYPE_CHECKING, Dict
+from proxlb.utils.logger import SystemdLogger
+from proxlb.utils.proxlb_data import ProxLbData
+from proxlb.utils.proxmox_api import ProxmoxApi
+
+if TYPE_CHECKING:
+    from proxmoxer_types.v9.core import ProxmoxAPI
+    NodeStorages = list[ProxmoxAPI.Nodes.Node.Storage._Get.TypedDict]
+    StorageContent = list[ProxmoxAPI.Nodes.Node.Storage.Storage.Content._Get.TypedDict]
+
+logger = SystemdLogger()
+
+# Volume content types that belong to guests and travel with them on
+# migration. Everything else (backup, iso, vztmpl, snippets, import) is
+# irrelevant for balancing and deliberately never queried.
+GUEST_CONTENT_TYPES = ("images", "rootdir")
+
+
+class Storage:
+    """
+    The Storage class retrieves the storage topology of a Proxmox cluster and
+    attributes guest disk usage to storages.
+
+    Methods:
+        __init__:
+            Initializes the Storage class.
+
+        get_storage(proxmox_api: ProxmoxApi, nodes: Dict[str, ProxLbData.Node]) -> Dict[str, ProxLbData.Storage]:
+            Collects per-node storage status and per-guest disk usage for all
+            storages in the cluster.
+
+        get_disks_for_guest(guest_id: int, storage: Dict[str, ProxLbData.Storage]) -> Dict[str, int]:
+            Returns the disk bytes of a single guest, keyed by storage id.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the Storage class with the provided ProxLB data.
+        """
+
+    @staticmethod
+    def get_storage(proxmox_api: ProxmoxApi, nodes: Dict[str, ProxLbData.Node]) -> Dict[str, ProxLbData.Storage]:
+        """
+        Collect storage topology and guest disk usage for the cluster.
+
+        This method iterates over all nodes and gathers each storage's
+        per-node capacity/availability, then lists the guest volumes
+        ('images' and 'rootdir' content) to attribute disk bytes to guests.
+        Shared storages are listed once, node-local storages per node.
+
+        API errors degrade gracefully: a node or storage that cannot be
+        queried is logged and skipped, so partial data is returned rather
+        than none.
+
+        Args:
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            nodes (Dict[str, ProxLbData.Node]): The nodes collected by Nodes.get_nodes.
+
+        Returns:
+            Dict[str, ProxLbData.Storage]: Storage entities keyed by storage id.
+        """
+        logger.debug("Starting: get_storage.")
+        storage: Dict[str, ProxLbData.Storage] = {}
+
+        # 1. Per-node storage status: capacity, availability and the
+        #    entity-level attributes (type, shared flag, content types).
+        for node_name in nodes.keys():
+            time.sleep(0.1)
+            try:
+                node_storages: 'NodeStorages' = proxmox_api.nodes(node_name).storage.get()
+            except Exception as proxmox_api_error:
+                logger.error(f"Failed to list storages on node: {node_name}: {proxmox_api_error}. Skipping node.")
+                continue
+
+            for entry in node_storages:
+                storage_name = entry["storage"]
+                if storage_name not in storage:
+                    storage[storage_name] = ProxLbData.Storage(
+                        name=storage_name,
+                        type=entry["type"],
+                        shared=bool(entry.get("shared", False)),
+                        content=[content_type for content_type in entry["content"].split(",") if content_type],
+                    )
+                storage[storage_name].nodes[node_name] = ProxLbData.Storage.NodeStatus(
+                    total=entry.get("total", 0),
+                    used=entry.get("used", 0),
+                    avail=entry.get("avail", 0),
+                    active=bool(entry.get("active", False)),
+                    enabled=bool(entry.get("enabled", True)),
+                )
+
+        # 2. Guest volumes: shared storages hold a single volume set, so one
+        #    active node is asked; node-local storages are independent
+        #    instances and every active one is asked.
+        for storage_name, storage_entity in storage.items():
+            content_types = [content_type for content_type in GUEST_CONTENT_TYPES if content_type in storage_entity.content]
+            if not content_types:
+                logger.debug(f"Storage: {storage_name} holds no guest content. Skipping content listing.")
+                continue
+
+            active_nodes = [node_name for node_name, status in storage_entity.nodes.items() if status.active and status.enabled]
+            if not active_nodes:
+                logger.debug(f"Storage: {storage_name} is not active on any node. Skipping content listing.")
+                continue
+
+            query_nodes = active_nodes[:1] if storage_entity.shared else active_nodes
+            for node_name in query_nodes:
+                for content_type in content_types:
+                    time.sleep(0.1)
+                    try:
+                        volumes: 'StorageContent' = proxmox_api.nodes(node_name).storage(storage_name).content.get(content=content_type)
+                    except Exception as proxmox_api_error:
+                        logger.error(f"Failed to list {content_type} content of storage: {storage_name} on node: {node_name}: {proxmox_api_error}. Skipping.")
+                        continue
+
+                    for volume in volumes:
+                        guest_id = volume.get("vmid")
+                        if guest_id is None:
+                            continue
+                        disks = storage_entity.guest_disks.setdefault(guest_id, ProxLbData.Storage.GuestDisks())
+                        # Allocated: actual consumption where the storage
+                        # reports it (thin storages), provisioned size
+                        # otherwise.
+                        used = volume.get("used")
+                        disks.allocated += used if used is not None else volume["size"]
+                        disks.provisioned += volume["size"]
+
+        logger.debug(f"Storage topology collected: {storage}")
+        logger.debug("Finished: get_storage.")
+        return storage
+
+    @staticmethod
+    def get_disks_for_guest(guest_id: int, storage: Dict[str, ProxLbData.Storage]) -> Dict[str, int]:
+        """
+        Return the allocated disk bytes of a single guest, keyed by storage id.
+
+        Args:
+            guest_id (int): The vmid of the guest.
+            storage (Dict[str, ProxLbData.Storage]): Storages from get_storage.
+
+        Returns:
+            Dict[str, int]: Disk bytes per storage id; storages without
+                volumes of this guest are omitted.
+        """
+        return {
+            storage_name: storage_entity.guest_disks[guest_id].allocated
+            for storage_name, storage_entity in storage.items()
+            if guest_id in storage_entity.guest_disks
+        }

--- a/proxlb/models/tests/test_guests_storage_wiring.py
+++ b/proxlb/models/tests/test_guests_storage_wiring.py
@@ -1,0 +1,96 @@
+from contextlib import ExitStack
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+from proxlb.models.guests import Guests
+from proxlb.models.ha_rules import HaRules
+from proxlb.models.ha_status import HaStatus
+from proxlb.models.pools import Pools
+from proxlb.models.tags import Tags
+from proxlb.utils.proxlb_data import ProxLbData
+from proxlb.utils.rrd import RrdDatasets
+
+_GiB = 1024 ** 3
+
+
+def _guest_listing(vmid: int, name: str) -> dict[str, Any]:
+    return {
+        "status": "running",
+        "vmid": vmid,
+        "name": name,
+        "cpus": 2,
+        "maxdisk": 10 * _GiB,
+        "disk": 0,
+        "maxmem": 4 * _GiB,
+        "mem": 2 * _GiB,
+    }
+
+
+def _storage(allocated_bytes: dict[int, int]) -> dict[str, ProxLbData.Storage]:
+    return {
+        "local": ProxLbData.Storage(
+            name="local",
+            type="dir",
+            content=["images", "rootdir"],
+            guest_disks={
+                guest_id: ProxLbData.Storage.GuestDisks(allocated=allocated)
+                for guest_id, allocated in allocated_bytes.items()
+            },
+        ),
+    }
+
+
+def _get_guests(vm_listing: list[dict[str, Any]], ct_listing: list[dict[str, Any]],
+                storage: dict[str, ProxLbData.Storage], ha_managed_sids: set[str]) -> dict[str, ProxLbData.Guest]:
+    proxmox_api = MagicMock()
+    proxmox_api.nodes.return_value.qemu.get.return_value = vm_listing
+    proxmox_api.nodes.return_value.lxc.get.return_value = ct_listing
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(Guests, "get_guest_rrd_datasets",
+                                         return_value=RrdDatasets(average=[], maximum=[])))
+        stack.enter_context(patch.object(HaStatus, "get_ha_managed_sids", return_value=ha_managed_sids))
+        stack.enter_context(patch.object(Tags, "get_tags_from_guests", return_value=[]))
+        stack.enter_context(patch.object(Tags, "get_affinity_groups", return_value=[]))
+        stack.enter_context(patch.object(Tags, "get_anti_affinity_groups", return_value=[]))
+        stack.enter_context(patch.object(Tags, "get_ignore", return_value=False))
+        stack.enter_context(patch.object(Tags, "get_node_relationships", return_value=[]))
+        stack.enter_context(patch.object(Pools, "get_pools_for_guest", return_value=[]))
+        stack.enter_context(patch.object(Pools, "get_pool_node_affinity_strictness", return_value=False))
+        stack.enter_context(patch.object(HaRules, "get_ha_rules_for_guest", return_value=[]))
+        return Guests.get_guests(
+            proxmox_api, {}, {},
+            cast(dict[str, ProxLbData.Node], {"node1": None}),
+            storage, MagicMock(),
+        )
+    raise AssertionError("unreachable")
+
+
+def test_vm_receives_disks_from_storage_collector() -> None:
+    """The per-guest disk map from Storage.get_disks_for_guest must land on Guest.disks."""
+    guests = _get_guests([_guest_listing(101, "vm1")], [], _storage({101: 7 * _GiB}), set())
+
+    assert guests["vm1"].disks == {"local": 7 * _GiB}
+
+
+def test_guest_without_volumes_has_empty_disks() -> None:
+    """A guest unknown to the storage collector must yield an empty disk map, not an error."""
+    guests = _get_guests([_guest_listing(101, "vm1")], [], _storage({}), set())
+
+    assert guests["vm1"].disks == {}
+
+
+def test_ha_managed_uses_vm_prefix_for_qemu_guests() -> None:
+    """A QEMU guest is HA-managed iff 'vm:<vmid>' is among the HA sids."""
+    guests = _get_guests([_guest_listing(101, "vm1")], [], _storage({}), {"vm:101"})
+
+    assert guests["vm1"].ha_managed is True
+
+
+def test_ha_managed_uses_ct_prefix_for_lxc_guests() -> None:
+    """An LXC guest must match on 'ct:<vmid>' and must not match a 'vm:' sid of the same vmid."""
+    guests = _get_guests([], [_guest_listing(201, "ct1")], _storage({}), {"vm:201"})
+    assert guests["ct1"].ha_managed is False
+
+    guests = _get_guests([], [_guest_listing(201, "ct1")], _storage({}), {"ct:201"})
+    assert guests["ct1"].ha_managed is True

--- a/proxlb/models/tests/test_ha_status_get_ha_managed_sids.py
+++ b/proxlb/models/tests/test_ha_status_get_ha_managed_sids.py
@@ -1,0 +1,39 @@
+"""
+Unit tests for HaStatus.get_ha_managed_sids().
+
+These tests verify that the sids of HA-managed resources are extracted from
+/cluster/ha/resources and that an API error safely degrades to an empty set,
+i.e. no guest is treated as HA-managed.
+"""
+
+from unittest.mock import MagicMock
+
+from proxlb.models.ha_status import HaStatus
+
+
+def test_returns_sids_of_all_ha_resources() -> None:
+    """Both VM and CT sids must be returned; entries without a sid are skipped."""
+    proxmox_api = MagicMock()
+    proxmox_api.cluster.ha.resources.get.return_value = [
+        {"sid": "vm:101", "type": "vm"},
+        {"sid": "ct:201", "type": "ct"},
+        {"type": "broken-entry-without-sid"},
+    ]
+
+    assert HaStatus.get_ha_managed_sids(proxmox_api) == {"vm:101", "ct:201"}
+
+
+def test_returns_empty_set_when_no_resources_are_ha_managed() -> None:
+    """A cluster without HA resources must yield an empty set."""
+    proxmox_api = MagicMock()
+    proxmox_api.cluster.ha.resources.get.return_value = []
+
+    assert HaStatus.get_ha_managed_sids(proxmox_api) == set()
+
+
+def test_api_error_degrades_to_no_ha_managed_guests() -> None:
+    """Failing to list HA resources must not abort collection; it degrades to 'not HA-managed'."""
+    proxmox_api = MagicMock()
+    proxmox_api.cluster.ha.resources.get.side_effect = Exception("API down")
+
+    assert HaStatus.get_ha_managed_sids(proxmox_api) == set()

--- a/proxlb/models/tests/test_storage_get_storage.py
+++ b/proxlb/models/tests/test_storage_get_storage.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for Storage.get_storage() and Storage.get_disks_for_guest().
+
+These tests verify the storage topology sweep: per-node status collection,
+the shared flag semantics (shared storages are content-listed once, local
+ones per node instance), the content type filtering (only guest content is
+ever listed), the used/size fallback when attributing volumes to guests, and
+graceful degradation on API errors.
+"""
+
+from typing import Any, cast
+from unittest.mock import patch
+
+from proxlb.models.storage import Storage
+from proxlb.utils.proxlb_data import ProxLbData
+from proxlb.utils.proxmox_api import ProxmoxApi
+
+_GiB = 1024 ** 3
+
+NodeStorages = dict[str, list[dict[str, Any]]]
+Contents = dict[tuple[str, str, str], list[dict[str, Any]]]
+
+
+class _FakeContentApi:
+    def __init__(self, api: "_FakeProxmoxApi", node: str, storage: str) -> None:
+        self._api, self._node, self._storage = api, node, storage
+
+    def get(self, content: str) -> list[dict[str, Any]]:
+        self._api.content_calls.append((self._node, self._storage, content))
+        return self._api.contents[(self._node, self._storage, content)]
+
+
+class _FakeStorageItemApi:
+    def __init__(self, api: "_FakeProxmoxApi", node: str, storage: str) -> None:
+        self.content = _FakeContentApi(api, node, storage)
+
+
+class _FakeStorageApi:
+    def __init__(self, api: "_FakeProxmoxApi", node: str) -> None:
+        self._api, self._node = api, node
+
+    def get(self) -> list[dict[str, Any]]:
+        return self._api.node_storages[self._node]
+
+    def __call__(self, storage_name: str) -> _FakeStorageItemApi:
+        return _FakeStorageItemApi(self._api, self._node, storage_name)
+
+
+class _FakeNodeApi:
+    def __init__(self, api: "_FakeProxmoxApi", node: str) -> None:
+        self.storage = _FakeStorageApi(api, node)
+
+
+class _FakeProxmoxApi:
+    """Stand-in for the node/storage/content part of the Proxmox API.
+
+    Unknown nodes or (node, storage, content) keys raise KeyError, which
+    doubles as the API error path in the degradation tests.
+    """
+
+    def __init__(self, node_storages: NodeStorages, contents: Contents) -> None:
+        self.node_storages = node_storages
+        self.contents = contents
+        self.content_calls: list[tuple[str, str, str]] = []
+
+    def nodes(self, node: str) -> _FakeNodeApi:
+        return _FakeNodeApi(self, node)
+
+
+def _nodes(*names: str) -> dict[str, ProxLbData.Node]:
+    """get_storage only iterates the keys, so stub values suffice."""
+    return cast(dict[str, ProxLbData.Node], {name: None for name in names})
+
+
+def _cluster_api() -> _FakeProxmoxApi:
+    """Two-node cluster: a local dir storage, a shared rbd storage, a
+    backup-only storage and a storage that is nowhere active."""
+    local = {"storage": "local", "type": "dir", "content": "images,rootdir,iso", "active": 1, "enabled": 1}
+    ceph = {"storage": "ceph", "type": "rbd", "shared": 1, "content": "images", "active": 1, "enabled": 1}
+    backup = {"storage": "backup", "type": "pbs", "shared": 1, "content": "backup", "active": 1, "enabled": 1}
+    return _FakeProxmoxApi(
+        node_storages={
+            "pve1": [
+                {**local, "total": 100 * _GiB, "used": 40 * _GiB, "avail": 60 * _GiB},
+                {**ceph, "total": 500 * _GiB, "used": 200 * _GiB, "avail": 300 * _GiB},
+                {**backup, "total": 1000 * _GiB, "used": 10 * _GiB, "avail": 990 * _GiB},
+            ],
+            "pve2": [
+                {**local, "total": 100 * _GiB, "used": 70 * _GiB, "avail": 30 * _GiB},
+                {**ceph, "total": 500 * _GiB, "used": 200 * _GiB, "avail": 300 * _GiB},
+                {"storage": "slow", "type": "dir", "content": "images", "active": 0},
+            ],
+        },
+        contents={
+            ("pve1", "local", "images"): [
+                {"volid": "local:101/vm-101-disk-0.qcow2", "vmid": 101, "size": 10 * _GiB, "used": 5 * _GiB, "format": "qcow2"},
+                {"volid": "local:101/vm-101-disk-1.qcow2", "vmid": 101, "size": 2 * _GiB, "format": "qcow2"},
+                {"volid": "local:iso/other.img", "size": 1 * _GiB, "format": "raw"},
+            ],
+            ("pve1", "local", "rootdir"): [
+                {"volid": "local:201/subvol-201-disk-0", "vmid": 201, "size": 8 * _GiB, "used": 0, "format": "subvol"},
+            ],
+            ("pve2", "local", "images"): [
+                {"volid": "local:102/vm-102-disk-0.qcow2", "vmid": 102, "size": 4 * _GiB, "used": 3 * _GiB, "format": "qcow2"},
+            ],
+            ("pve2", "local", "rootdir"): [],
+            ("pve1", "ceph", "images"): [
+                {"volid": "ceph:vm-101-disk-0", "vmid": 101, "size": 20 * _GiB, "format": "raw"},
+            ],
+            ("pve2", "ceph", "images"): [
+                {"volid": "ceph:vm-101-disk-0", "vmid": 101, "size": 20 * _GiB, "format": "raw"},
+            ],
+        },
+    )
+
+
+def _collect(api: _FakeProxmoxApi, *node_names: str) -> dict[str, ProxLbData.Storage]:
+    with patch("proxlb.models.storage.time.sleep"):
+        return Storage.get_storage(cast(ProxmoxApi, api), _nodes(*node_names))
+
+
+def test_entity_attributes_and_per_node_status_are_collected() -> None:
+    """Storage entities carry type, shared flag and content; per-node status carries independent capacities."""
+    storage = _collect(_cluster_api(), "pve1", "pve2")
+
+    assert storage["local"].shared is False  # 'shared' key absent must default to False
+    assert storage["ceph"].shared is True
+    assert storage["local"].type == "dir"
+    assert storage["local"].content == ["images", "rootdir", "iso"]
+    assert storage["local"].nodes["pve1"].avail == 60 * _GiB
+    assert storage["local"].nodes["pve2"].avail == 30 * _GiB
+    assert storage["slow"].nodes.keys() == {"pve2"}  # config 'nodes' restriction: absent node means unavailable
+
+
+def test_shared_storage_is_content_listed_exactly_once() -> None:
+    """A shared storage is a single volume set; listing it per node would double-count guests."""
+    api = _cluster_api()
+    storage = _collect(api, "pve1", "pve2")
+
+    ceph_calls = [call for call in api.content_calls if call[1] == "ceph"]
+    assert len(ceph_calls) == 1
+    assert storage["ceph"].guest_disks.keys() == {101}
+    assert storage["ceph"].guest_disks[101].allocated == 20 * _GiB
+
+
+def test_local_storage_is_content_listed_per_active_node_and_merged() -> None:
+    """Node-local instances are independent; each active one is listed and vmid sums are merged."""
+    api = _cluster_api()
+    storage = _collect(api, "pve1", "pve2")
+
+    local_nodes = {call[0] for call in api.content_calls if call[1] == "local"}
+    assert local_nodes == {"pve1", "pve2"}
+    assert storage["local"].guest_disks[102].allocated == 3 * _GiB
+
+
+def test_only_guest_content_types_are_listed() -> None:
+    """Backup-only storages are never content-listed; 'iso' is never requested on mixed storages."""
+    api = _cluster_api()
+    _collect(api, "pve1", "pve2")
+
+    assert all(call[1] != "backup" for call in api.content_calls)
+    assert all(call[2] in ("images", "rootdir") for call in api.content_calls)
+
+
+def test_inactive_storage_is_not_content_listed() -> None:
+    """A storage without any active node instance has no listable volumes."""
+    api = _cluster_api()
+    storage = _collect(api, "pve1", "pve2")
+
+    assert all(call[1] != "slow" for call in api.content_calls)
+    assert storage["slow"].guest_disks == {}
+
+
+def test_volume_bytes_prefer_used_and_fall_back_to_size() -> None:
+    """'used' reflects actual allocation and wins where reported (an explicit
+    0 is meaningful for thin volumes); 'size' is the fallback."""
+    storage = _collect(_cluster_api(), "pve1", "pve2")
+
+    # vm-101 on local: disk-0 reports used=5G, disk-1 reports no 'used' -> size=2G
+    assert storage["local"].guest_disks[101].allocated == 7 * _GiB
+    # ct-201: explicit used=0 must not fall back to size
+    assert storage["local"].guest_disks[201].allocated == 0
+
+
+def test_volumes_without_vmid_are_ignored() -> None:
+    """Volumes not owned by a guest must not be attributed to anyone."""
+    storage = _collect(_cluster_api(), "pve1", "pve2")
+
+    owners = set(storage["local"].guest_disks)
+    assert owners == {101, 102, 201}
+
+
+def test_api_errors_degrade_to_partial_data() -> None:
+    """An unreachable node is skipped; data from the remaining nodes is returned."""
+    storage = _collect(_cluster_api(), "pve1", "pve2", "pve3")
+
+    assert storage["local"].nodes.keys() == {"pve1", "pve2"}
+    assert storage["local"].guest_disks[101].allocated == 7 * _GiB
+
+
+def test_get_disks_for_guest_maps_storages_to_bytes() -> None:
+    """The per-guest view spans all storages holding volumes of the guest and omits the others."""
+    storage = _collect(_cluster_api(), "pve1", "pve2")
+
+    assert Storage.get_disks_for_guest(101, storage) == {"local": 7 * _GiB, "ceph": 20 * _GiB}
+    assert Storage.get_disks_for_guest(102, storage) == {"local": 3 * _GiB}
+    assert Storage.get_disks_for_guest(999, storage) == {}
+
+
+def test_provisioned_sums_collected_alongside_allocated() -> None:
+    """'provisioned' always sums the volume 'size': it differs from
+    'allocated' exactly where a thin storage reports 'used'."""
+    storage = _collect(_cluster_api(), "pve1", "pve2")
+
+    # vm-101 on local: sizes 10G + 2G; the allocated view is 5G + 2G.
+    assert storage["local"].guest_disks[101].provisioned == 12 * _GiB
+    assert storage["local"].guest_disks[101].allocated == 7 * _GiB
+    # ct-201: used=0 but provisioned 8G.
+    assert storage["local"].guest_disks[201].provisioned == 8 * _GiB
+    # ceph volume reports no 'used': both views agree on the size.
+    assert storage["ceph"].guest_disks[101].provisioned == storage["ceph"].guest_disks[101].allocated == 20 * _GiB

--- a/proxlb/utils/proxlb_data.py
+++ b/proxlb/utils/proxlb_data.py
@@ -130,6 +130,50 @@ class ProxLbData(BaseModel):
         name: str
         members: list[str] = []
 
+    class Storage(BaseModel):
+        """
+        A storage entity from the cluster-wide storage configuration.
+
+        Storage ids are cluster-global: a non-shared storage (e.g. 'local')
+        is one definition instantiated independently on every node listed in
+        'nodes', while a shared storage is a single instance visible from all
+        of them. The per-node status therefore carries identical numbers for
+        shared storages and independent capacities for local ones.
+        """
+        class NodeStatus(BaseModel):
+            total: int = 0
+            used: int = 0
+            avail: int = 0
+            active: bool = False
+            enabled: bool = True
+
+        class GuestDisks(BaseModel):
+            # Bytes actually consumed ('used' where the storage reports it,
+            # provisioned size otherwise — on thick storages the two
+            # coincide).
+            allocated: int = 0
+            # Configured upper bound: the sum of the volume sizes.
+            provisioned: int = 0
+
+        name: str
+        type: str
+        # Proxmox trusts this configuration flag to decide whether a
+        # migration needs to copy disks; consumers should do the same.
+        shared: bool = False
+        content: list[str] = []
+        # Per-node availability and capacity. Note that storages restricted
+        # to specific nodes (config 'nodes' option) still appear in the other
+        # nodes' listings with zeroed capacity and active/enabled False, so
+        # consumers must filter on those flags, not on key presence.
+        nodes: dict[str, NodeStatus] = {}
+        # Disk bytes of each guest on this storage, keyed by guest id (the
+        # Proxmox 'vmid'; VMs and CTs share one id namespace), summed over
+        # all 'images' (VM) and 'rootdir' (CT) volumes owned by that guest.
+        # For non-shared storages the sums span all node instances, so
+        # leftover volumes on other nodes are (conservatively) attributed
+        # as well.
+        guest_disks: dict[int, GuestDisks] = {}
+
     class HaRule(BaseModel):
         rule: str
         type: AffinityType

--- a/proxlb/utils/proxlb_data.py
+++ b/proxlb/utils/proxlb_data.py
@@ -81,6 +81,10 @@ class ProxLbData(BaseModel):
         node_relationships: list[str]
         node_relationships_strict: bool
         type: GuestType
+        # True when the guest is managed by the Proxmox HA stack
+        # (/cluster/ha/resources). HA-routed migrations do not forward a
+        # target storage parameter, so such guests cannot be remapped.
+        ha_managed: bool
 
         def metric(self, name: BalancingResource) -> Metric:
             if name == BalancingResource.Cpu:

--- a/proxlb/utils/proxlb_data.py
+++ b/proxlb/utils/proxlb_data.py
@@ -81,6 +81,13 @@ class ProxLbData(BaseModel):
         node_relationships: list[str]
         node_relationships_strict: bool
         type: GuestType
+        # Disk bytes attributed to this guest per storage id, from the storage
+        # content listings (actual allocation where the storage reports it,
+        # provisioned size otherwise). Unlike the 'disk' metric above this is
+        # populated for QEMU guests as well and carries the storage id, so
+        # consumers can distinguish shared from node-local volumes via
+        # ProxLbData.storage. Empty when storage collection is unavailable.
+        disks: dict[str, int]
         # True when the guest is managed by the Proxmox HA stack
         # (/cluster/ha/resources). HA-routed migrations do not forward a
         # target storage parameter, so such guests cannot be remapped.
@@ -186,3 +193,4 @@ class ProxLbData(BaseModel):
     meta: Meta
     nodes: dict[str, Node]
     pools: dict[str, Pool]
+    storage: dict[str, Storage]

--- a/tests/test_calculations_relocate_guests.py
+++ b/tests/test_calculations_relocate_guests.py
@@ -109,6 +109,7 @@ def _make_guest(
         cpu=cpu,
         memory=mem,
         disk=disk,
+        disks={},
         ha_managed=False,
     )
 
@@ -165,6 +166,7 @@ def _build_stacking_scenario() -> ProxLbData:
         ha_rules={},
         nodes=nodes,
         pools={},
+        storage={},
         groups=ProxLbData.Groups(affinity=affinity),
         meta=ProxLbData.Meta(
             proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),
@@ -289,6 +291,7 @@ def test_real_world_scenario() -> None:
         ha_rules={},
         nodes=nodes,
         pools={},
+        storage={},
         groups=ProxLbData.Groups(affinity=affinity),
         meta=ProxLbData.Meta(
             proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),

--- a/tests/test_calculations_relocate_guests.py
+++ b/tests/test_calculations_relocate_guests.py
@@ -109,6 +109,7 @@ def _make_guest(
         cpu=cpu,
         memory=mem,
         disk=disk,
+        ha_managed=False,
     )
 
 

--- a/tests/test_predictive_check.py
+++ b/tests/test_predictive_check.py
@@ -97,6 +97,7 @@ def _make_guest(name: str, node: str, memory_gb: float) -> ProxLbData.Guest:
         cpu=cpu,
         memory=mem,
         disk=disk,
+        ha_managed=False,
     )
 
 

--- a/tests/test_predictive_check.py
+++ b/tests/test_predictive_check.py
@@ -97,6 +97,7 @@ def _make_guest(name: str, node: str, memory_gb: float) -> ProxLbData.Guest:
         cpu=cpu,
         memory=mem,
         disk=disk,
+        disks={},
         ha_managed=False,
     )
 
@@ -114,6 +115,7 @@ def _build_proxlb_data(
         ha_rules={},
         nodes=nodes,
         pools={},
+        storage={},
         groups=ProxLbData.Groups(affinity={}),
         meta=ProxLbData.Meta(
             proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,4 +63,5 @@ def create_guest(name: str, node_current: str, node_target: str) -> ProxLbData.G
         node_relationships=[],
         node_relationships_strict=False,
         type=Config.GuestType.Vm,
+        ha_managed=False,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from proxlb.utils.config_parser import Config
 
 
 MINIMAL_DATA = ProxLbData(
-    guests={}, ha_rules={}, nodes={}, pools={}, groups=ProxLbData.Groups(),
+    guests={}, ha_rules={}, nodes={}, pools={}, storage={}, groups=ProxLbData.Groups(),
     meta=ProxLbData.Meta(
         proxmox_api=Config.ProxmoxAPI(hosts=[], user=""),
         cluster_non_pve9=False,
@@ -63,5 +63,6 @@ def create_guest(name: str, node_current: str, node_target: str) -> ProxLbData.G
         node_relationships=[],
         node_relationships_strict=False,
         type=Config.GuestType.Vm,
+        disks={},
         ha_managed=False,
     )


### PR DESCRIPTION
This change is a preparation to closing issue #115. ProxLB now gathers all migration-relevant disk metrics for further decision making. One such instance of decision making is planned via https://github.com/credativ/proxlb-solver/pull/13.

This PR does not change disk-based decisions in the legacy (non-`proxlb-solver`) migration logic.