### PR TITLE
fix: Reduce extra RRD API calls for guest/node metric collection (#122)

### DIFF
--- a/.changelogs/2.2.1/122-fix-slow-rrd-metrics-collection.yml
+++ b/.changelogs/2.2.1/122-fix-slow-rrd-metrics-collection.yml
@@ -7,3 +7,8 @@ fixed:
 - Fix CT (LXC) guests being queried via the qemu API endpoint instead of the
   lxc endpoint when collecting RRD data, which silently returned 0.0 for all
   CT pressure/usage metrics (@archandha). [#122]
+- Type the rrddata responses via proxmoxer-stubs so that RRD field names are
+  checked against the fields Proxmox actually reports.
+- Fix disk pressure being read from a non-existing 'pressuredisk{some,full}'
+  RRD field, which silently returned 0.0 for nodes and guests alike. Proxmox
+  reports this as io pressure, so 'pressureio{some,full}' is read instead.

--- a/.changelogs/2.2.1/122-fix-slow-rrd-metrics-collection.yml
+++ b/.changelogs/2.2.1/122-fix-slow-rrd-metrics-collection.yml
@@ -1,0 +1,9 @@
+fixed:
+- Reduce RRD metrics collection time by no longer querying the same rrddata
+  endpoint once per individual metric; a single AVERAGE and a single MAX
+  request per guest/node already contain all cpu, memory, disk and pressure
+  (PSI) values, cutting RRD API calls per guest from 13 to 2 and per node
+  from 12 to 2 (@archandha). [#122]
+- Fix CT (LXC) guests being queried via the qemu API endpoint instead of the
+  lxc endpoint when collecting RRD data, which silently returned 0.0 for all
+  CT pressure/usage metrics (@archandha). [#122]

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -274,7 +274,7 @@ class Guests:
             rrd_data_value = max(_rrd_data_value[-6:], default=0.0)
         else:
             # Calculate the average value from the RRD data entries
-            rrd_data_value = sum(value for entry in guest_data_rrd if (value := entry.get(rrd_key)) is not None) / len(guest_data_rrd)
+            rrd_data_value = sum(entry[rrd_key] for entry in guest_data_rrd if rrd_key in entry and entry[rrd_key] is not None) / len(guest_data_rrd)  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
         logger.debug(f"RRD data (spike: {spikes}) for {rrd_key} from guest: {vm_name}: {rrd_data_value}")
         logger.debug("Finished: get_guest_rrd_value.")

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -270,11 +270,11 @@ class Guests:
         if spikes:
             # RRD data is collected every minute, so we look at the last 6 entries
             # and take the maximum value to represent the spike
-            _rrd_data_value = [row[rrd_key] for row in guest_data_rrd if rrd_key in row]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            _rrd_data_value = [value for row in guest_data_rrd if (value := row.get(rrd_key)) is not None]
             rrd_data_value = max(_rrd_data_value[-6:], default=0.0)
         else:
             # Calculate the average value from the RRD data entries
-            rrd_data_value = sum(entry[rrd_key] for entry in guest_data_rrd if rrd_key in entry) / len(guest_data_rrd)  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            rrd_data_value = sum(value for entry in guest_data_rrd if (value := entry.get(rrd_key)) is not None) / len(guest_data_rrd)
 
         logger.debug(f"RRD data (spike: {spikes}) for {rrd_key} from guest: {vm_name}: {rrd_data_value}")
         logger.debug("Finished: get_guest_rrd_value.")

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -77,34 +77,35 @@ class Guests:
                     guest_tags = Tags.get_tags_from_guests(proxmox_api, node, guest['vmid'], GuestType.Vm)
                     guest_pools = Pools.get_pools_for_guest(guest['name'], pools)
                     guest_ha_rules = HaRules.get_ha_rules_for_guest(guest['name'], ha_rules, guest['vmid'])
+                    guest_rrd_average, guest_rrd_max = Guests.get_guest_rrd_datasets(proxmox_api, node, guest['vmid'], guest['name'], GuestType.Vm)
 
                     guests[guest['name']] = ProxLbData.Guest(
                         name=guest['name'],
                         cpu=ProxLbData.Guest.Metric(
                             total=int(guest['cpus']),
-                            used=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', None),
-                            pressure_some_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'full', spikes=True),
+                            used=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', None),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full', spikes=True),
                             pressure_hot=False,
                         ),
                         disk=ProxLbData.Guest.Metric(
                             total=guest['maxdisk'],
                             used=guest['disk'],
-                            pressure_some_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full', spikes=True),
                             pressure_hot=False,
                         ),
                         memory=ProxLbData.Guest.Metric(
                             total=guest['maxmem'],
                             used=guest['mem'],
-                            pressure_some_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full', spikes=True),
                             pressure_hot=False,
                         ),
                         id=guest['vmid'],
@@ -136,33 +137,34 @@ class Guests:
                     guest_tags = Tags.get_tags_from_guests(proxmox_api, node, guest['vmid'], GuestType.Ct)
                     guest_pools = Pools.get_pools_for_guest(guest['name'], pools)
                     guest_ha_rules = HaRules.get_ha_rules_for_guest(guest['name'], ha_rules, guest['vmid'])
+                    guest_rrd_average, guest_rrd_max = Guests.get_guest_rrd_datasets(proxmox_api, node, guest['vmid'], guest['name'], GuestType.Ct)
 
                     guests[guest['name']] = ProxLbData.Guest(
                         cpu=ProxLbData.Guest.Metric(
                             total=int(guest['cpus']),
-                            used=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', None),
-                            pressure_some_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'cpu', 'full', spikes=True),
+                            used=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', None),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full', spikes=True),
                             pressure_hot=False,
                         ),
                         disk=ProxLbData.Guest.Metric(
                             total=guest['maxdisk'],
                             used=guest['disk'],
-                            pressure_some_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'disk', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full', spikes=True),
                             pressure_hot=False,
                         ),
                         memory=ProxLbData.Guest.Metric(
                             total=guest['maxmem'],
                             used=guest['mem'],
-                            pressure_some_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_data(proxmox_api, node, guest['vmid'], guest['name'], 'memory', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full', spikes=True),
                             pressure_hot=False,
                         ),
                         name=guest['name'],
@@ -190,14 +192,63 @@ class Guests:
         return guests
 
     @staticmethod
-    def get_guest_rrd_data(proxmox_api: ProxmoxApi, node_name: str, vm_id: int, vm_name: str, object_name: str, object_type: Optional[str], spikes: bool = False) -> float:
+    def get_guest_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str, vm_id: int, vm_name: str, guest_type: Config.GuestType) -> tuple:
         """
-        Retrieves the rrd data metrics for a specific resource (CPU, memory, disk) of a guest VM or CT.
+        Fetches the RRD data for a guest VM or CT once, covering both the average and
+        maximum (spike) consolidation functions.
+
+        A single Proxmox RRD response already contains every metric (cpu, memory, disk
+        usage as well as all of their pressure figures) for the requested timeframe.
+        Fetching it once per consolidation function (AVERAGE/MAX) and deriving all
+        individual values from it via get_guest_rrd_value() avoids querying the same
+        endpoint repeatedly (previously up to 13 times per guest).
 
         Args:
-            proxmox_api (Any): The Proxmox API client instance.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
             node_name (str): The name of the node hosting the guest.
             vm_id (int): The ID of the guest VM or CT.
+            vm_name (str): The name of the guest VM or CT.
+            guest_type (GuestType): Whether the guest is a VM (qemu) or CT (lxc).
+
+        Returns:
+            tuple[list, list]: The (average, max) RRD data entries for the guest.
+        """
+        logger.debug("Starting: get_guest_rrd_datasets.")
+
+        if guest_type == GuestType.Vm:
+            guest_api_endpoint = proxmox_api.nodes(node_name).qemu(vm_id)
+        else:
+            guest_api_endpoint = proxmox_api.nodes(node_name).lxc(vm_id)
+
+        time.sleep(0.1)
+        try:
+            logger.debug(f"Getting average RRD data from guest: {vm_name}.")
+            rrd_average = guest_api_endpoint.rrddata.get(timeframe="hour", cf="AVERAGE")
+        except Exception:
+            logger.error(f"Failed to retrieve AVERAGE RRD data for guest: {vm_name} (ID: {vm_id}) on node: {node_name}. Using 0.0 as value.")
+            rrd_average = []
+
+        time.sleep(0.1)
+        try:
+            logger.debug(f"Getting spike RRD data from guest: {vm_name}.")
+            rrd_max = guest_api_endpoint.rrddata.get(timeframe="hour", cf="MAX")
+        except Exception:
+            logger.error(f"Failed to retrieve MAX RRD data for guest: {vm_name} (ID: {vm_id}) on node: {node_name}. Using 0.0 as value.")
+            rrd_max = []
+
+        logger.debug("Finished: get_guest_rrd_datasets.")
+        return rrd_average, rrd_max
+
+    @staticmethod
+    def get_guest_rrd_value(rrd_average: list, rrd_max: list, vm_name: str, object_name: str, object_type: Optional[str], spikes: bool = False) -> float:
+        """
+        Derives a single rrd data metric (CPU, memory, disk usage or pressure) of a guest
+        VM or CT from the datasets already fetched via get_guest_rrd_datasets(). This
+        performs no API call itself.
+
+        Args:
+            rrd_average (list): The RRD entries fetched with cf="AVERAGE".
+            rrd_max (list): The RRD entries fetched with cf="MAX".
             vm_name (str): The name of the guest VM or CT.
             object_name (str): The resource type to query (e.g., 'cpu', 'memory', 'disk').
             object_type (str, optional): The pressure type ('some', 'full') or None for average usage.
@@ -206,19 +257,11 @@ class Guests:
         Returns:
             float: The calculated average usage value for the specified resource.
         """
-        logger.debug("Starting: get_guest_rrd_data.")
-        time.sleep(0.1)
+        logger.debug("Starting: get_guest_rrd_value.")
+        guest_data_rrd = rrd_max if spikes else rrd_average
 
-        try:
-            if spikes:
-                logger.debug(f"Getting spike RRD data for {object_name} from guest: {vm_name}.")
-                guest_data_rrd = proxmox_api.nodes(node_name).qemu(vm_id).rrddata.get(timeframe="hour", cf="MAX")
-            else:
-                logger.debug(f"Getting average RRD data for {object_name} from guest: {vm_name}.")
-                guest_data_rrd = proxmox_api.nodes(node_name).qemu(vm_id).rrddata.get(timeframe="hour", cf="AVERAGE")
-        except Exception:
-            logger.error(f"Failed to retrieve RRD data for guest: {vm_name} (ID: {vm_id}) on node: {node_name}. Using 0.0 as value.")
-            logger.debug("Finished: get_guest_rrd_data.")
+        if not guest_data_rrd:
+            logger.debug("Finished: get_guest_rrd_value.")
             return float(0.0)
 
         if object_type:
@@ -240,5 +283,5 @@ class Guests:
             rrd_data_value = sum(entry.get("cpu", 0.0) for entry in guest_data_rrd) / len(guest_data_rrd)
 
         logger.debug(f"RRD data (spike: {spikes}) for {object_name} from guest: {vm_name}: {rrd_data_value}")
-        logger.debug("Finished: get_guest_rrd_data.")
+        logger.debug("Finished: get_guest_rrd_value.")
         return rrd_data_value

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -8,15 +8,19 @@ __copyright__ = "Copyright (C) 2025 Florian Paul Azim Hoberg (@gyptazy)"
 __license__ = "GPL-3.0"
 
 
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 from proxlb.utils.logger import SystemdLogger
 from proxlb.utils.proxmox_api import ProxmoxApi
 from proxlb.utils.config_parser import Config
 from proxlb.utils.proxlb_data import ProxLbData
+from proxlb.utils.rrd import GuestRrdKey, RrdDatasets
 from proxlb.models.pools import Pools
 from proxlb.models.ha_rules import HaRules
 from proxlb.models.tags import Tags
 import time
+
+if TYPE_CHECKING:
+    from proxlb.utils.rrd import GuestRrdDatasets
 
 GuestType = Config.GuestType
 
@@ -77,35 +81,35 @@ class Guests:
                     guest_tags = Tags.get_tags_from_guests(proxmox_api, node, guest['vmid'], GuestType.Vm)
                     guest_pools = Pools.get_pools_for_guest(guest['name'], pools)
                     guest_ha_rules = HaRules.get_ha_rules_for_guest(guest['name'], ha_rules, guest['vmid'])
-                    guest_rrd_average, guest_rrd_max = Guests.get_guest_rrd_datasets(proxmox_api, node, guest['vmid'], guest['name'], GuestType.Vm)
+                    guest_rrd = Guests.get_guest_rrd_datasets(proxmox_api, node, guest['vmid'], guest['name'], GuestType.Vm)
 
                     guests[guest['name']] = ProxLbData.Guest(
                         name=guest['name'],
                         cpu=ProxLbData.Guest.Metric(
                             total=int(guest['cpus']),
-                            used=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', None),
-                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full', spikes=True),
+                            used=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'cpu'),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpusome'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpufull'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpusome', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpufull', spikes=True),
                             pressure_hot=False,
                         ),
                         disk=ProxLbData.Guest.Metric(
                             total=guest['maxdisk'],
                             used=guest['disk'],
-                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiosome'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiofull'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiosome', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiofull', spikes=True),
                             pressure_hot=False,
                         ),
                         memory=ProxLbData.Guest.Metric(
                             total=guest['maxmem'],
                             used=guest['mem'],
-                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememorysome'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememoryfull'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememorysome', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememoryfull', spikes=True),
                             pressure_hot=False,
                         ),
                         id=guest['vmid'],
@@ -137,34 +141,34 @@ class Guests:
                     guest_tags = Tags.get_tags_from_guests(proxmox_api, node, guest['vmid'], GuestType.Ct)
                     guest_pools = Pools.get_pools_for_guest(guest['name'], pools)
                     guest_ha_rules = HaRules.get_ha_rules_for_guest(guest['name'], ha_rules, guest['vmid'])
-                    guest_rrd_average, guest_rrd_max = Guests.get_guest_rrd_datasets(proxmox_api, node, guest['vmid'], guest['name'], GuestType.Ct)
+                    guest_rrd = Guests.get_guest_rrd_datasets(proxmox_api, node, guest['vmid'], guest['name'], GuestType.Ct)
 
                     guests[guest['name']] = ProxLbData.Guest(
                         cpu=ProxLbData.Guest.Metric(
                             total=int(guest['cpus']),
-                            used=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', None),
-                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'cpu', 'full', spikes=True),
+                            used=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'cpu'),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpusome'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpufull'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpusome', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurecpufull', spikes=True),
                             pressure_hot=False,
                         ),
                         disk=ProxLbData.Guest.Metric(
                             total=guest['maxdisk'],
                             used=guest['disk'],
-                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'disk', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiosome'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiofull'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiosome', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressureiofull', spikes=True),
                             pressure_hot=False,
                         ),
                         memory=ProxLbData.Guest.Metric(
                             total=guest['maxmem'],
                             used=guest['mem'],
-                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some'),
-                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full'),
-                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'some', spikes=True),
-                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd_average, guest_rrd_max, guest['name'], 'memory', 'full', spikes=True),
+                            pressure_some_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememorysome'),
+                            pressure_full_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememoryfull'),
+                            pressure_some_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememorysome', spikes=True),
+                            pressure_full_spikes_percent=Guests.get_guest_rrd_value(guest_rrd, guest['name'], 'pressurememoryfull', spikes=True),
                             pressure_hot=False,
                         ),
                         name=guest['name'],
@@ -192,7 +196,7 @@ class Guests:
         return guests
 
     @staticmethod
-    def get_guest_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str, vm_id: int, vm_name: str, guest_type: Config.GuestType) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:
+    def get_guest_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str, vm_id: int, vm_name: str, guest_type: Config.GuestType) -> 'GuestRrdDatasets':
         """
         Fetches the RRD data for a guest VM or CT once, covering both the average and
         maximum (spike) consolidation functions.
@@ -211,7 +215,7 @@ class Guests:
             guest_type (GuestType): Whether the guest is a VM (qemu) or CT (lxc).
 
         Returns:
-            tuple[list, list]: The (average, max) RRD data entries for the guest.
+            GuestRrdDatasets: The average and maximum RRD data entries for the guest.
         """
         logger.debug("Starting: get_guest_rrd_datasets.")
 
@@ -237,51 +241,41 @@ class Guests:
             rrd_max = []
 
         logger.debug("Finished: get_guest_rrd_datasets.")
-        return rrd_average, rrd_max
+        return RrdDatasets(average=rrd_average, maximum=rrd_max)
 
     @staticmethod
-    def get_guest_rrd_value(rrd_average: list[Dict[str, Any]], rrd_max: list[Dict[str, Any]], vm_name: str, object_name: str, object_type: Optional[str], spikes: bool = False) -> float:
+    def get_guest_rrd_value(rrd_datasets: 'GuestRrdDatasets', vm_name: str, rrd_key: GuestRrdKey, spikes: bool = False) -> float:
         """
         Derives a single rrd data metric (CPU, memory, disk usage or pressure) of a guest
         VM or CT from the datasets already fetched via get_guest_rrd_datasets(). This
         performs no API call itself.
 
         Args:
-            rrd_average (list): The RRD entries fetched with cf="AVERAGE".
-            rrd_max (list): The RRD entries fetched with cf="MAX".
+            rrd_datasets (GuestRrdDatasets): The RRD entries fetched for both consolidation functions.
             vm_name (str): The name of the guest VM or CT.
-            object_name (str): The resource type to query (e.g., 'cpu', 'memory', 'disk').
-            object_type (str, optional): The pressure type ('some', 'full') or None for average usage.
+            rrd_key (GuestRrdKey): The rrd field to read.
             spikes (bool, optional): Whether to consider spikes in the calculation. Defaults to False.
 
         Returns:
             float: The calculated average usage value for the specified resource.
         """
         logger.debug("Starting: get_guest_rrd_value.")
-        guest_data_rrd = rrd_max if spikes else rrd_average
+        guest_data_rrd = rrd_datasets.maximum if spikes else rrd_datasets.average
 
         if not guest_data_rrd:
             logger.debug("Finished: get_guest_rrd_value.")
             return float(0.0)
 
-        if object_type:
-
-            lookup_key = f"pressure{object_name}{object_type}"
-            if spikes:
-                # RRD data is collected every minute, so we look at the last 6 entries
-                # and take the maximum value to represent the spike
-                logger.debug(f"Getting RRD data (spike: {spikes}) of pressure for {object_name} {object_type} from guest: {vm_name}.")
-                _rrd_data_value = [row[lookup_key] for row in guest_data_rrd if row.get(lookup_key) is not None]
-                rrd_data_value = max(_rrd_data_value[-6:], default=0.0)
-            else:
-                # Calculate the average value from the RRD data entries
-                logger.debug(f"Getting RRD data (spike: {spikes}) of pressure for {object_name} {object_type} from guest: {vm_name}.")
-                rrd_data_value = sum(entry.get(lookup_key, 0.0) for entry in guest_data_rrd) / len(guest_data_rrd)
-
+        logger.debug(f"Getting RRD data (spike: {spikes}) for {rrd_key} from guest: {vm_name}.")
+        if spikes:
+            # RRD data is collected every minute, so we look at the last 6 entries
+            # and take the maximum value to represent the spike
+            _rrd_data_value = [row[rrd_key] for row in guest_data_rrd if rrd_key in row]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            rrd_data_value = max(_rrd_data_value[-6:], default=0.0)
         else:
-            logger.debug(f"Getting RRD data of cpu usage from guest: {vm_name}.")
-            rrd_data_value = sum(entry.get("cpu", 0.0) for entry in guest_data_rrd) / len(guest_data_rrd)
+            # Calculate the average value from the RRD data entries
+            rrd_data_value = sum(entry[rrd_key] for entry in guest_data_rrd if rrd_key in entry) / len(guest_data_rrd)  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
-        logger.debug(f"RRD data (spike: {spikes}) for {object_name} from guest: {vm_name}: {rrd_data_value}")
+        logger.debug(f"RRD data (spike: {spikes}) for {rrd_key} from guest: {vm_name}: {rrd_data_value}")
         logger.debug("Finished: get_guest_rrd_value.")
         return rrd_data_value

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -270,7 +270,7 @@ class Guests:
         if spikes:
             # RRD data is collected every minute, so we look at the last 6 entries
             # and take the maximum value to represent the spike
-            _rrd_data_value = [value for row in guest_data_rrd if (value := row.get(rrd_key)) is not None]
+            _rrd_data_value = [row[rrd_key] for row in guest_data_rrd if rrd_key in row and row[rrd_key] is not None]  # pyright: ignore[reportTypedDictNotRequiredAccess]
             rrd_data_value = max(_rrd_data_value[-6:], default=0.0)
         else:
             # Calculate the average value from the RRD data entries

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -8,7 +8,7 @@ __copyright__ = "Copyright (C) 2025 Florian Paul Azim Hoberg (@gyptazy)"
 __license__ = "GPL-3.0"
 
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from proxlb.utils.logger import SystemdLogger
 from proxlb.utils.proxmox_api import ProxmoxApi
 from proxlb.utils.config_parser import Config
@@ -192,7 +192,7 @@ class Guests:
         return guests
 
     @staticmethod
-    def get_guest_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str, vm_id: int, vm_name: str, guest_type: Config.GuestType) -> tuple:
+    def get_guest_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str, vm_id: int, vm_name: str, guest_type: Config.GuestType) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:
         """
         Fetches the RRD data for a guest VM or CT once, covering both the average and
         maximum (spike) consolidation functions.
@@ -240,7 +240,7 @@ class Guests:
         return rrd_average, rrd_max
 
     @staticmethod
-    def get_guest_rrd_value(rrd_average: list, rrd_max: list, vm_name: str, object_name: str, object_type: Optional[str], spikes: bool = False) -> float:
+    def get_guest_rrd_value(rrd_average: list[Dict[str, Any]], rrd_max: list[Dict[str, Any]], vm_name: str, object_name: str, object_type: Optional[str], spikes: bool = False) -> float:
         """
         Derives a single rrd data metric (CPU, memory, disk usage or pressure) of a guest
         VM or CT from the datasets already fetched via get_guest_rrd_datasets(). This
@@ -271,7 +271,7 @@ class Guests:
                 # RRD data is collected every minute, so we look at the last 6 entries
                 # and take the maximum value to represent the spike
                 logger.debug(f"Getting RRD data (spike: {spikes}) of pressure for {object_name} {object_type} from guest: {vm_name}.")
-                _rrd_data_value = [row.get(lookup_key) for row in guest_data_rrd if row.get(lookup_key) is not None]
+                _rrd_data_value = [row[lookup_key] for row in guest_data_rrd if row.get(lookup_key) is not None]
                 rrd_data_value = max(_rrd_data_value[-6:], default=0.0)
             else:
                 # Calculate the average value from the RRD data entries

--- a/proxlb/models/nodes.py
+++ b/proxlb/models/nodes.py
@@ -267,12 +267,12 @@ class Nodes:
             # RRD data is collected every minute, so we look at the last 6 entries
             # and take the maximum value to represent the spike
             rrd_data_value = max(
-                [value for row in node_data_rrd if (value := row.get(rrd_key)) is not None][-6:],
+                [row[rrd_key] for row in node_data_rrd if rrd_key in row and row[rrd_key] is not None][-6:],  # pyright: ignore[reportTypedDictNotRequiredAccess]
                 default=0.0,
             )
         else:
             # Calculate the average value from the RRD data entries
-            rrd_data_value = sum(value for entry in node_data_rrd if (value := entry.get(rrd_key)) is not None) / len(node_data_rrd)
+            rrd_data_value = sum(entry[rrd_key] for entry in node_data_rrd if rrd_key in entry and entry[rrd_key] is not None) / len(node_data_rrd)  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
         logger.debug(f"RRD data (spike: {spikes}) for {rrd_key} from node: {node_name}: {rrd_data_value}")
         logger.debug("Finished: get_node_rrd_value.")

--- a/proxlb/models/nodes.py
+++ b/proxlb/models/nodes.py
@@ -73,6 +73,7 @@ class Nodes:
                 disk_used = node["disk"]
                 memory_used = node["mem"]
                 memory_free = node["maxmem"] - node["mem"]
+                node_rrd_average, node_rrd_max = Nodes.get_node_rrd_datasets(proxmox_api, node["node"])
 
                 nodes[node["node"]] = ProxLbData.Node(
                     name=node["node"],
@@ -87,10 +88,10 @@ class Nodes:
                         assigned_percent=0,
                         free_percent=cpu_free / node["maxcpu"] * 100,
                         used_percent=cpu_used / node["maxcpu"] * 100,
-                        pressure_some_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "cpu", "some"),
-                        pressure_full_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "cpu", "full"),
-                        pressure_some_spikes_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "cpu", "some", spikes=True),
-                        pressure_full_spikes_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "cpu", "full", spikes=True),
+                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "some"),
+                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "full"),
+                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "some", spikes=True),
+                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "full", spikes=True),
                         pressure_hot=False,
                     ),
                     disk=ProxLbData.Node.Metric(
@@ -101,10 +102,10 @@ class Nodes:
                         assigned_percent=0,
                         free_percent=disk_free / node["maxdisk"] * 100,
                         used_percent=disk_used / node["maxdisk"] * 100,
-                        pressure_some_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "disk", "some"),
-                        pressure_full_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "disk", "full"),
-                        pressure_some_spikes_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "disk", "some", spikes=True),
-                        pressure_full_spikes_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "disk", "full", spikes=True),
+                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "some"),
+                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "full"),
+                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "some", spikes=True),
+                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "full", spikes=True),
                         pressure_hot=False,
                     ),
                     memory=ProxLbData.Node.Metric(
@@ -115,10 +116,10 @@ class Nodes:
                         assigned_percent=0,
                         free_percent=memory_free / node["maxmem"] * 100,
                         used_percent=memory_used / node["maxmem"] * 100,
-                        pressure_some_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "memory", "some"),
-                        pressure_full_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "memory", "full"),
-                        pressure_some_spikes_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "memory", "some", spikes=True),
-                        pressure_full_spikes_percent=Nodes.get_node_rrd_data(proxmox_api, node["node"], "memory", "full", spikes=True),
+                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "some"),
+                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "full"),
+                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "some", spikes=True),
+                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "full", spikes=True),
                         pressure_hot=False,
                     ),
                 )
@@ -196,13 +197,56 @@ class Nodes:
         return False
 
     @staticmethod
-    def get_node_rrd_data(proxmox_api: ProxmoxApi, node_name: str, object_name: str, object_type: str, spikes: bool = False) -> float:
+    def get_node_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str) -> tuple:
         """
-        Retrieves the rrd data metrics for a specific resource (CPU, memory, disk) of a node.
+        Fetches the RRD data for a node once, covering both the average and maximum
+        (spike) consolidation functions.
+
+        A single Proxmox RRD response already contains every metric (cpu, memory, disk
+        usage as well as all of their pressure figures) for the requested timeframe.
+        Fetching it once per consolidation function (AVERAGE/MAX) and deriving all
+        individual values from it via get_node_rrd_value() avoids querying the same
+        endpoint repeatedly (previously up to 12 times per node).
 
         Args:
-            proxmox_api (Any): The Proxmox API client instance.
-            node_name (str): The name of the node hosting the guest.
+            proxmox_api (ProxmoxApi): The Proxmox API client instance.
+            node_name (str): The name of the node.
+
+        Returns:
+            tuple[list, list]: The (average, max) RRD data entries for the node.
+        """
+        logger.debug("Starting: get_node_rrd_datasets.")
+
+        time.sleep(0.1)
+        try:
+            logger.debug(f"Getting average RRD data from node: {node_name}.")
+            rrd_average = proxmox_api.nodes(node_name).rrddata.get(timeframe="hour", cf="AVERAGE")
+        except Exception:
+            logger.error(f"Failed to retrieve AVERAGE RRD data for node: {node_name}. Using 0.0 as value.")
+            rrd_average = []
+
+        time.sleep(0.1)
+        try:
+            logger.debug(f"Getting spike RRD data from node: {node_name}.")
+            rrd_max = proxmox_api.nodes(node_name).rrddata.get(timeframe="hour", cf="MAX")
+        except Exception:
+            logger.error(f"Failed to retrieve MAX RRD data for node: {node_name}. Using 0.0 as value.")
+            rrd_max = []
+
+        logger.debug("Finished: get_node_rrd_datasets.")
+        return rrd_average, rrd_max
+
+    @staticmethod
+    def get_node_rrd_value(rrd_average: list, rrd_max: list, node_name: str, object_name: str, object_type: str, spikes: bool = False) -> float:
+        """
+        Derives a single rrd data metric (CPU, memory, disk pressure) of a node from the
+        datasets already fetched via get_node_rrd_datasets(). This performs no API call
+        itself.
+
+        Args:
+            rrd_average (list): The RRD entries fetched with cf="AVERAGE".
+            rrd_max (list): The RRD entries fetched with cf="MAX".
+            node_name (str): The name of the node.
             object_name (str): The resource type to query (e.g., 'cpu', 'memory', 'disk').
             object_type (str, optional): The pressure type ('some', 'full') or None for average usage.
             spikes (bool, optional): Whether to consider spikes in the calculation. Defaults to False.
@@ -210,20 +254,11 @@ class Nodes:
         Returns:
             float: The calculated average usage value for the specified resource.
         """
-        logger.debug("Starting: get_node_rrd_data.")
-        time.sleep(0.1)
+        logger.debug("Starting: get_node_rrd_value.")
+        node_data_rrd = rrd_max if spikes else rrd_average
 
-        try:
-            if spikes:
-                logger.debug(f"Getting spike RRD data for {object_name} from node: {node_name}.")
-                node_data_rrd = proxmox_api.nodes(node_name).rrddata.get(timeframe="hour", cf="MAX")
-            else:
-                logger.debug(f"Getting average RRD data for {object_name} from node: {node_name}.")
-                node_data_rrd = proxmox_api.nodes(node_name).rrddata.get(timeframe="hour", cf="AVERAGE")
-
-        except Exception:
-            logger.error(f"Failed to retrieve RRD data for guest: {node_name}. Using 0.0 as value.")
-            logger.debug("Finished: get_node_rrd_data.")
+        if not node_data_rrd:
+            logger.debug("Finished: get_node_rrd_value.")
             return 0.0
 
         lookup_key = f"pressure{object_name}{object_type}"
@@ -240,7 +275,7 @@ class Nodes:
             rrd_data_value = sum(entry.get(lookup_key, 0.0) for entry in node_data_rrd) / len(node_data_rrd)
 
         logger.debug(f"RRD data (spike: {spikes}) for {object_name} from node: {node_name}: {rrd_data_value}")
-        logger.debug("Finished: get_node_rrd_data.")
+        logger.debug("Finished: get_node_rrd_value.")
         return rrd_data_value
 
     @staticmethod

--- a/proxlb/models/nodes.py
+++ b/proxlb/models/nodes.py
@@ -22,7 +22,7 @@ __license__ = "GPL-3.0"
 
 
 import time
-from typing import Dict
+from typing import Any, Dict
 from proxlb.utils.config_parser import Config
 from proxlb.utils.logger import SystemdLogger
 from proxlb.utils.proxlb_data import ProxLbData
@@ -197,7 +197,7 @@ class Nodes:
         return False
 
     @staticmethod
-    def get_node_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str) -> tuple:
+    def get_node_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:
         """
         Fetches the RRD data for a node once, covering both the average and maximum
         (spike) consolidation functions.
@@ -237,7 +237,7 @@ class Nodes:
         return rrd_average, rrd_max
 
     @staticmethod
-    def get_node_rrd_value(rrd_average: list, rrd_max: list, node_name: str, object_name: str, object_type: str, spikes: bool = False) -> float:
+    def get_node_rrd_value(rrd_average: list[Dict[str, Any]], rrd_max: list[Dict[str, Any]], node_name: str, object_name: str, object_type: str, spikes: bool = False) -> float:
         """
         Derives a single rrd data metric (CPU, memory, disk pressure) of a node from the
         datasets already fetched via get_node_rrd_datasets(). This performs no API call
@@ -267,7 +267,7 @@ class Nodes:
             # RRD data is collected every minute, so we look at the last 6 entries
             # and take the maximum value to represent the spike
             rrd_data_value = max(
-                [row.get(lookup_key) for row in node_data_rrd if row.get(lookup_key) is not None][-6:],
+                [row[lookup_key] for row in node_data_rrd if row.get(lookup_key) is not None][-6:],
                 default=0.0,
             )
         else:

--- a/proxlb/models/nodes.py
+++ b/proxlb/models/nodes.py
@@ -267,12 +267,12 @@ class Nodes:
             # RRD data is collected every minute, so we look at the last 6 entries
             # and take the maximum value to represent the spike
             rrd_data_value = max(
-                [row[rrd_key] for row in node_data_rrd if rrd_key in row][-6:],  # pyright: ignore[reportTypedDictNotRequiredAccess]
+                [value for row in node_data_rrd if (value := row.get(rrd_key)) is not None][-6:],
                 default=0.0,
             )
         else:
             # Calculate the average value from the RRD data entries
-            rrd_data_value = sum(entry[rrd_key] for entry in node_data_rrd if rrd_key in entry) / len(node_data_rrd)  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            rrd_data_value = sum(value for entry in node_data_rrd if (value := entry.get(rrd_key)) is not None) / len(node_data_rrd)
 
         logger.debug(f"RRD data (spike: {spikes}) for {rrd_key} from node: {node_name}: {rrd_data_value}")
         logger.debug("Finished: get_node_rrd_value.")

--- a/proxlb/models/nodes.py
+++ b/proxlb/models/nodes.py
@@ -22,11 +22,15 @@ __license__ = "GPL-3.0"
 
 
 import time
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Dict
 from proxlb.utils.config_parser import Config
 from proxlb.utils.logger import SystemdLogger
 from proxlb.utils.proxlb_data import ProxLbData
 from proxlb.utils.proxmox_api import ProxmoxApi
+from proxlb.utils.rrd import NodeRrdKey, RrdDatasets
+
+if TYPE_CHECKING:
+    from proxlb.utils.rrd import NodeRrdDatasets
 
 BalancingResource = Config.Balancing.Resource
 
@@ -73,7 +77,7 @@ class Nodes:
                 disk_used = node["disk"]
                 memory_used = node["mem"]
                 memory_free = node["maxmem"] - node["mem"]
-                node_rrd_average, node_rrd_max = Nodes.get_node_rrd_datasets(proxmox_api, node["node"])
+                node_rrd = Nodes.get_node_rrd_datasets(proxmox_api, node["node"])
 
                 nodes[node["node"]] = ProxLbData.Node(
                     name=node["node"],
@@ -88,10 +92,10 @@ class Nodes:
                         assigned_percent=0,
                         free_percent=cpu_free / node["maxcpu"] * 100,
                         used_percent=cpu_used / node["maxcpu"] * 100,
-                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "some"),
-                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "full"),
-                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "some", spikes=True),
-                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "cpu", "full", spikes=True),
+                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressurecpusome"),
+                        pressure_full_percent=0.0,  # There is no pressure_full for nodes, only for guests
+                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressurecpusome", spikes=True),
+                        pressure_full_spikes_percent=0.0,
                         pressure_hot=False,
                     ),
                     disk=ProxLbData.Node.Metric(
@@ -102,10 +106,10 @@ class Nodes:
                         assigned_percent=0,
                         free_percent=disk_free / node["maxdisk"] * 100,
                         used_percent=disk_used / node["maxdisk"] * 100,
-                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "some"),
-                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "full"),
-                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "some", spikes=True),
-                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "disk", "full", spikes=True),
+                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressureiosome"),
+                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressureiofull"),
+                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressureiosome", spikes=True),
+                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressureiofull", spikes=True),
                         pressure_hot=False,
                     ),
                     memory=ProxLbData.Node.Metric(
@@ -116,10 +120,10 @@ class Nodes:
                         assigned_percent=0,
                         free_percent=memory_free / node["maxmem"] * 100,
                         used_percent=memory_used / node["maxmem"] * 100,
-                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "some"),
-                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "full"),
-                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "some", spikes=True),
-                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd_average, node_rrd_max, node["node"], "memory", "full", spikes=True),
+                        pressure_some_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressurememorysome"),
+                        pressure_full_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressurememoryfull"),
+                        pressure_some_spikes_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressurememorysome", spikes=True),
+                        pressure_full_spikes_percent=Nodes.get_node_rrd_value(node_rrd, node["node"], "pressurememoryfull", spikes=True),
                         pressure_hot=False,
                     ),
                 )
@@ -197,7 +201,7 @@ class Nodes:
         return False
 
     @staticmethod
-    def get_node_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:
+    def get_node_rrd_datasets(proxmox_api: ProxmoxApi, node_name: str) -> 'NodeRrdDatasets':
         """
         Fetches the RRD data for a node once, covering both the average and maximum
         (spike) consolidation functions.
@@ -213,7 +217,7 @@ class Nodes:
             node_name (str): The name of the node.
 
         Returns:
-            tuple[list, list]: The (average, max) RRD data entries for the node.
+            NodeRrdDatasets: The average and maximum RRD data entries for the node.
         """
         logger.debug("Starting: get_node_rrd_datasets.")
 
@@ -234,47 +238,43 @@ class Nodes:
             rrd_max = []
 
         logger.debug("Finished: get_node_rrd_datasets.")
-        return rrd_average, rrd_max
+        return RrdDatasets(average=rrd_average, maximum=rrd_max)
 
     @staticmethod
-    def get_node_rrd_value(rrd_average: list[Dict[str, Any]], rrd_max: list[Dict[str, Any]], node_name: str, object_name: str, object_type: str, spikes: bool = False) -> float:
+    def get_node_rrd_value(rrd_datasets: 'NodeRrdDatasets', node_name: str, rrd_key: NodeRrdKey, spikes: bool = False) -> float:
         """
         Derives a single rrd data metric (CPU, memory, disk pressure) of a node from the
         datasets already fetched via get_node_rrd_datasets(). This performs no API call
         itself.
 
         Args:
-            rrd_average (list): The RRD entries fetched with cf="AVERAGE".
-            rrd_max (list): The RRD entries fetched with cf="MAX".
+            rrd_datasets (NodeRrdDatasets): The RRD entries fetched for both consolidation functions.
             node_name (str): The name of the node.
-            object_name (str): The resource type to query (e.g., 'cpu', 'memory', 'disk').
-            object_type (str, optional): The pressure type ('some', 'full') or None for average usage.
+            rrd_key (NodeRrdKey): The rrd field to read.
             spikes (bool, optional): Whether to consider spikes in the calculation. Defaults to False.
 
         Returns:
             float: The calculated average usage value for the specified resource.
         """
         logger.debug("Starting: get_node_rrd_value.")
-        node_data_rrd = rrd_max if spikes else rrd_average
+        node_data_rrd = rrd_datasets.maximum if spikes else rrd_datasets.average
 
         if not node_data_rrd:
             logger.debug("Finished: get_node_rrd_value.")
             return 0.0
 
-        lookup_key = f"pressure{object_name}{object_type}"
-
         if spikes:
             # RRD data is collected every minute, so we look at the last 6 entries
             # and take the maximum value to represent the spike
             rrd_data_value = max(
-                [row[lookup_key] for row in node_data_rrd if row.get(lookup_key) is not None][-6:],
+                [row[rrd_key] for row in node_data_rrd if rrd_key in row][-6:],  # pyright: ignore[reportTypedDictNotRequiredAccess]
                 default=0.0,
             )
         else:
             # Calculate the average value from the RRD data entries
-            rrd_data_value = sum(entry.get(lookup_key, 0.0) for entry in node_data_rrd) / len(node_data_rrd)
+            rrd_data_value = sum(entry[rrd_key] for entry in node_data_rrd if rrd_key in entry) / len(node_data_rrd)  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
-        logger.debug(f"RRD data (spike: {spikes}) for {object_name} from node: {node_name}: {rrd_data_value}")
+        logger.debug(f"RRD data (spike: {spikes}) for {rrd_key} from node: {node_name}: {rrd_data_value}")
         logger.debug("Finished: get_node_rrd_value.")
         return rrd_data_value
 

--- a/proxlb/utils/rrd.py
+++ b/proxlb/utils/rrd.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, Literal, TypeAlias, TypeVar
+
+RrdEntry = TypeVar("RrdEntry")
+
+
+@dataclass
+class RrdDatasets(Generic[RrdEntry]):
+    average: list[RrdEntry]
+    maximum: list[RrdEntry]
+
+
+# The rrd fields we read, named as in pve-cluster.git src/pmxcfs/status.c.
+NodeRrdKey: TypeAlias = Literal[
+    "pressurecpusome",
+    "pressureiosome",
+    "pressureiofull",
+    "pressurememorysome",
+    "pressurememoryfull",
+]
+
+GuestRrdKey: TypeAlias = Literal[
+    "cpu",
+    "pressurecpusome",
+    "pressurecpufull",
+    "pressureiosome",
+    "pressureiofull",
+    "pressurememorysome",
+    "pressurememoryfull",
+]
+
+if TYPE_CHECKING:
+    from proxmoxer_types.v9.core import ProxmoxAPI
+
+    NodeRrdDatasets: TypeAlias = RrdDatasets[ProxmoxAPI.Nodes.Node.Rrddata._Get.TypedDict]
+    GuestRrdDatasets: TypeAlias = (
+        RrdDatasets[ProxmoxAPI.Nodes.Node.Qemu.Vmid.Rrddata._Get.TypedDict]
+        | RrdDatasets[ProxmoxAPI.Nodes.Node.Lxc.Vmid.Rrddata._Get.TypedDict]
+    )


### PR DESCRIPTION
## Summary

Fixes #122. Collecting RRD metrics was slow (~2s per guest, ~13 min for
460 VMs) because `Guests.get_guest_rrd_data()` and `Nodes.get_node_rrd_data()`
queried the same `rrddata` endpoint once per individual metric , each preceded by an 
0.1s delay to throttle the pressure on the API.

A single Proxmox `rrddata` response for a given `cf` (AVERAGE/MAX) already
contains every metric (cpu, mem, disk usage and all pressure/PSI fields) at
once, so all but 2 of those calls per guest/node were redundant. This should improve
speed significantly. 

Please test this with a larger VM set if possible.