### PR TITLE
Fix(node-pinning): Cast node names when comparing to lower case

### DIFF
--- a/.changelogs/2.3.0/127-fix-cast-node-names-to-lower-for-validation.yml
+++ b/.changelogs/2.3.0/127-fix-cast-node-names-to-lower-for-validation.yml
@@ -1,0 +1,3 @@
+fixed:
+- Cast node names when comparing to lower case as tags within the PVE API cast all strings to lower which affects node pinning. [#127|
+- Returning the original node name for the generated `guest_node_relation_list` list when evaluating most free node. [#127]

--- a/proxlb/models/tags.py
+++ b/proxlb/models/tags.py
@@ -258,7 +258,7 @@ class Tags:
                     _node_name = Helper.validate_node_presence(node_relationship_tag, nodes)
                     if _node_name:
                         logger.debug(f"Tag {node_relationship_tag} is valid! Defined node exists in the cluster.")
-                        logger.debug(f"Setting node relationship because of tag {tag} to {node_relationship_tag}.")
+                        logger.debug(f"Setting node relationship because of tag {tag} to {_node_name}.")
                         node_relationship_tags.append(_node_name)
                     else:
                         logger.warning(f"Tag {node_relationship_tag} is invalid! Defined node does not exist in the cluster. Not applying pinning.")

--- a/proxlb/models/tags.py
+++ b/proxlb/models/tags.py
@@ -255,10 +255,11 @@ class Tags:
                     node_relationship_tag = tag.replace("plb_pin_", "")
 
                     # Validate if the node to pin is present in the cluster
-                    if Helper.validate_node_presence(node_relationship_tag, nodes):
+                    _node_name = Helper.validate_node_presence(node_relationship_tag, nodes)
+                    if _node_name:
                         logger.debug(f"Tag {node_relationship_tag} is valid! Defined node exists in the cluster.")
                         logger.debug(f"Setting node relationship because of tag {tag} to {node_relationship_tag}.")
-                        node_relationship_tags.append(node_relationship_tag)
+                        node_relationship_tags.append(_node_name)
                     else:
                         logger.warning(f"Tag {node_relationship_tag} is invalid! Defined node does not exist in the cluster. Not applying pinning.")
 

--- a/proxlb/utils/helper.py
+++ b/proxlb/utils/helper.py
@@ -357,7 +357,7 @@ class Helper:
                 return host_object, 8006
 
     @staticmethod
-    def validate_node_presence(node: str, nodes: Dict[str, ProxLbData.Node]) -> bool:
+    def validate_node_presence(node: str, nodes: Dict[str, ProxLbData.Node]) -> Optional[str]:
         """
         Validates whether a given node exists in the provided cluster nodes dictionary.
 
@@ -367,18 +367,19 @@ class Helper:
                                     Must include a "nodes" key mapping to a dict of available nodes.
 
         Returns:
-            bool: True if the node exists in the cluster, False otherwise.
+            Optional[str]: Name of the node if matching.
         """
         logger.debug("Starting: validate_node_presence.")
 
-        if node in nodes.keys():
-            logger.info(f"Node {node} found in cluster. Applying pinning.")
-            logger.debug("Finished: validate_node_presence.")
-            return True
-        else:
-            logger.warning(f"Node {node} not found in cluster. Not applying pinning!")
-            logger.debug("Finished: validate_node_presence.")
-            return False
+        for _node in nodes:
+            if node.lower() == _node.lower():
+                logger.info(f"Node {node} found in cluster. Applying pinning.")
+                logger.debug("Finished: validate_node_presence.")
+                return _node
+
+        logger.warning(f"Node {node} not found in cluster. Not applying pinning!")
+        logger.debug("Finished: validate_node_presence.")
+        return None
 
     @staticmethod
     def tcp_connect_test(addr_family: int, host: str, port: int, timeout: int) -> tuple[bool, Optional[int]]:


### PR DESCRIPTION
Fix(node-pinning): Cast node names when comparing to lower case
                   as tags within the PVE API cast all strings
                   to lower which affects node pinning.

Fixes: #127 (req. by @KernelChief)
Sponsored-by: @KernelChief